### PR TITLE
Re-design of resources shared with test (MQTT client access, logging)

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,11 +8,12 @@ import qualified Data.HashMap.Strict as M
 import qualified Network.MQTT.Client as MQTT
 import Network.MQTT.Topic (toFilter)
 import qualified Service.App as App
+import Service.App (Logger)
 import qualified Service.Daemon as Daemon
 import qualified Service.Env as Env
-import Service.Env (Config, LoggerVariant (TFLogger), MQTTDispatch, logLevel, mqttConfig)
+import Service.Env (Config, MQTTDispatch, logLevel, mqttConfig)
 import Service.MQTT.Client (initMQTTClient, mqttClientCallback)
-import System.Log.FastLogger (newTimedFastLogger)
+import System.Log.FastLogger (TimedFastLogger, newTimedFastLogger)
 import UnliftIO.STM (TVar, readTVarIO)
 
 
@@ -25,16 +26,17 @@ import UnliftIO.STM (TVar, readTVarIO)
 configFilePath :: FilePath
 configFilePath = "config.dhall"
 
-mkLogger :: Config -> IO (LoggerVariant, IO ())
+mkLogger :: Config -> IO (TimedFastLogger, IO ())
 mkLogger config' = do
   (fmtTime, logType) <- App.loggerConfig config'
   -- TODO handle failure to open/write to file properly
   (tfLogger, cleanup) <- newTimedFastLogger fmtTime logType
-  pure (TFLogger tfLogger, cleanup)
+  pure (tfLogger, cleanup)
 
 mkMQTTClient
-  :: Config
-  -> LoggerVariant
+  :: (Logger logger)
+  => Config
+  -> logger
   -> TVar MQTTDispatch
   -> IO (MQTT.MQTTClient, IO ())
 mkMQTTClient config logger mqttDispatch = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,8 +10,7 @@ import Network.MQTT.Topic (toFilter)
 import qualified Service.App as App
 import qualified Service.Daemon as Daemon
 import qualified Service.Env as Env
-import Service.Env (Config, LoggerVariant (TFLogger), MQTTClientVariant (..), MQTTDispatch,
-                    logLevel, mqttConfig)
+import Service.Env (Config, LoggerVariant (TFLogger), MQTTDispatch, logLevel, mqttConfig)
 import Service.MQTT.Client (initMQTTClient, mqttClientCallback)
 import System.Log.FastLogger (newTimedFastLogger)
 import UnliftIO.STM (TVar, readTVarIO)
@@ -34,7 +33,10 @@ mkLogger config' = do
   pure (TFLogger tfLogger, cleanup)
 
 mkMQTTClient
-  :: Config -> LoggerVariant -> TVar MQTTDispatch -> IO (MQTTClientVariant, IO ())
+  :: Config
+  -> LoggerVariant
+  -> TVar MQTTDispatch
+  -> IO (MQTT.MQTTClient, IO ())
 mkMQTTClient config logger mqttDispatch = do
   mqttDispatch' <- readTVarIO mqttDispatch
 
@@ -47,7 +49,7 @@ mkMQTTClient config logger mqttDispatch = do
   mc <- initMQTTClient (mqttClientCallback logLevelSet logger mqttDispatch) mqttConfig'
   (_eithers, _props) <- MQTT.subscribe mc mqttSubs []
 
-  pure (MCClient $ mc, MQTT.normalDisconnect mc)
+  pure (mc, MQTT.normalDisconnect mc)
 
 
 main :: IO ()

--- a/automation-service.cabal
+++ b/automation-service.cabal
@@ -85,6 +85,7 @@ library
   hs-source-dirs:   src
   exposed-modules:
       Service.App
+    , Service.App.Logger
     , Service.Automation
     , Service.AutomationName
     , Service.Automations

--- a/automation-service.cabal
+++ b/automation-service.cabal
@@ -84,26 +84,28 @@ library
   import:           shared
   hs-source-dirs:   src
   exposed-modules:
-      Service.Automation
+      Service.App
+    , Service.Automation
     , Service.AutomationName
     , Service.Automations
     , Service.Automations.Gold
     , Service.Automations.HTTP
     , Service.Automations.LuaScript
     , Service.Automations.StateManager
-    , Service.App
     , Service.Daemon
-    , Service.TimeHelpers
     , Service.Device
-    , Service.Group
     , Service.Env
+    , Service.Env.Config
+    , Service.Group
+    , Service.MQTT.Class
+    , Service.MQTT.Client
     , Service.MQTT.Messages.Daemon
     , Service.MQTT.Messages.Lighting
-    , Service.MQTT.Client
     , Service.MQTT.Status
     , Service.MQTT.Topic
     , Service.MQTT.Zigbee2MQTT
     , Service.StateStore
+    , Service.TimeHelpers
 
 executable automation-service
   import:           shared
@@ -130,11 +132,11 @@ test-suite automation-service-tests
       Test.Helpers
     , Test.Integration.Service.Daemon
     , Test.Integration.Service.DaemonTestHelpers
-    , Test.Unit.Service.TimeHelpers
     , Test.Unit.Service.Device
     , Test.Unit.Service.Group
     , Test.Unit.Service.MQTT.Messages.Daemon
     , Test.Unit.Service.MQTT.Status
+    , Test.Unit.Service.TimeHelpers
   build-depends:
       automation-service
     , hspec ^>= 2.9.7

--- a/src/Service/App.hs
+++ b/src/Service/App.hs
@@ -1,18 +1,20 @@
 module Service.App
-  ( AutomationService
-  , Logger(..)
+  ( module Service.App.Logger
+  , AutomationService
+  , debug
+  , error
   , findDeviceM
-  , log
+  , info
   , logDefault
-  , logWithVariant
   , loggerConfig
   , publish
   , runAutomationService
   , subscribe
+  , warn
   )
   where
 
-import Prelude hiding (log)
+import Prelude hiding (error, log)
 
 import Control.Lens (view, (^.))
 import Control.Monad (when)
@@ -21,65 +23,51 @@ import Control.Monad.Reader (MonadIO, MonadReader (..), ReaderT, liftIO, runRead
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.HashMap.Strict as M
 import Data.Text (Text)
-import qualified Data.Text as T
 import Network.MQTT.Client (Topic)
+import Service.App.Logger (Logger (..))
 import Service.Device (Device, DeviceId)
-import Service.Env (Config, Env, LogLevel (..), LoggerVariant (..), config,
-                    devices, logFilePath, logLevel, logger, mqttClient)
+import Service.Env (Config, Env, LogLevel (..), config, devices, logFilePath, logLevel, logger,
+                    mqttClient)
 import Service.MQTT.Class (MQTTClient (..))
 import System.Log.FastLogger (FileLogSpec (..), FormattedTime, LogType, LogType' (..),
-                              TimedFastLogger, ToLogStr (..), defaultBufSize, newTimeCache,
-                              simpleTimeFormat)
-import UnliftIO.STM (atomically, modifyTVar', readTVar)
+                              defaultBufSize, newTimeCache, simpleTimeFormat)
+import UnliftIO.STM (atomically, readTVar)
 
-newtype AutomationService mqttClient a = AutomationService (ReaderT (Env mqttClient) IO a)
+newtype AutomationService logger mqttClient a
+  = AutomationService (ReaderT (Env logger mqttClient) IO a)
   deriving
     ( Functor
     , Applicative
     , Monad
     , MonadIO
-    , MonadReader (Env mqttClient)
+    , MonadReader (Env logger mqttClient)
     , MonadUnliftIO
     )
 
-runAutomationService :: Env mqttClient -> AutomationService mqttClient a -> IO a
+runAutomationService :: Env logger mqttClient -> AutomationService logger mqttClient a -> IO a
 runAutomationService env (AutomationService x) = runReaderT x env
 
 -- Logger
 
-class (Monad m) => Logger m where
-  debug :: Text -> m ()
-  info :: Text -> m ()
-  warn :: Text -> m ()
-  error :: Text -> m ()
+debug, info, warn, error
+  :: (Logger logger, MonadIO m, MonadReader (Env logger mqttClient) m)
+  => Text
+  -> m ()
+debug = logDefault Debug
+info = logDefault Info
+warn = logDefault Warn
+error = logDefault Error
 
-instance Logger (AutomationService mqttClient) where
-  debug = logDefault Debug
-  info = logDefault Info
-  warn = logDefault Warn
-  error = logDefault Error
-
-logDefault :: (MonadIO m, MonadReader (Env mqttClient) m) => LogLevel -> Text -> m ()
+logDefault
+  :: (Logger logger, MonadIO m, MonadReader (Env logger mqttClient) m)
+  => LogLevel
+  -> Text
+  -> m ()
 logDefault level logStr = do
   setLevel <- view (config . logLevel)
   when (level >= setLevel) $ do
     logger' <- view logger
-    liftIO $ logWithVariant logger' level logStr
-
-logWithVariant :: LoggerVariant -> LogLevel -> Text -> IO ()
-logWithVariant logger' level logStr =
-  -- LoggerVariant and related boilerplate is all for testing
-  -- purposes, mostly because spinning up multiple TimedFastLogger
-  -- instances at the same time seems to scramble tests ONLY when
-  -- building with nix (╯°□°）╯︵ ┻━┻
-  case logger' of
-    TFLogger tfLogger -> log tfLogger level $ logStr
-    QLogger qLogger -> atomically . modifyTVar' qLogger $ \msgs ->
-      msgs <> [ T.pack (show level) <> ": " <> logStr ]
-
-log :: (ToLogStr s) => TimedFastLogger -> LogLevel -> s -> IO ()
-log logger' level logStr = logger' $ \time ->
-  toLogStr (show level) <> " - " <> toLogStr time <> " - " <> toLogStr logStr <> "\n"
+    liftIO $ log logger' level logStr
 
 {-|
   Given a Env.Config, returns an IO-wrapped (IO FormattedTime,
@@ -100,12 +88,17 @@ loggerConfig config' = do
 -- MQTTClient helpers
 
 publish
-  :: (MQTTClient mc, MonadReader (Env mc) m, MonadIO m) => Topic -> ByteString -> m ()
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadIO m)
+  => Topic
+  -> ByteString
+  -> m ()
 publish topic msg =
   view mqttClient >>= \mc -> liftIO $ publishMQTT mc topic msg
 
 subscribe
-  :: (MQTTClient mc, MonadReader (Env mc) m, MonadIO m) => Topic -> m ()
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadIO m)
+  => Topic
+  -> m ()
 subscribe topic =
   view mqttClient >>= \mc -> liftIO $ subscribeMQTT mc topic
 
@@ -113,7 +106,7 @@ subscribe topic =
 -- not sure where to put this, but eventually I want to just get rid
 -- of it
 findDeviceM
-  :: (MonadIO m, MonadReader (Env mqttClient) m)
+  :: (MonadIO m, MonadReader (Env logger mqttClient) m)
   => DeviceId
   -> m (Maybe Device)
 findDeviceM deviceId = do

--- a/src/Service/App/Logger.hs
+++ b/src/Service/App/Logger.hs
@@ -1,0 +1,15 @@
+module Service.App.Logger
+  ( Logger(..)
+  )
+where
+
+import Data.Text (Text)
+import Service.Env.Config (LogLevel (..))
+import System.Log.FastLogger (TimedFastLogger, ToLogStr (..))
+
+class Logger l where
+  log :: l -> LogLevel -> Text -> IO ()
+
+instance Logger TimedFastLogger where
+  log logger' level logStr = logger' $ \time ->
+    toLogStr (show level) <> " - " <> toLogStr time <> " - " <> toLogStr logStr <> "\n"

--- a/src/Service/Automations.hs
+++ b/src/Service/Automations.hs
@@ -17,7 +17,7 @@ import Service.Env (Env)
 import Service.MQTT.Class (MQTTClient)
 
 findAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => AutomationName
   -> (UTCTime -> Automation m)
 findAutomation = \case

--- a/src/Service/Automations.hs
+++ b/src/Service/Automations.hs
@@ -6,7 +6,7 @@ where
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Reader (MonadReader)
 import Data.Time.Clock (UTCTime)
-import Service.App (Logger, MonadMQTT)
+import Service.App (Logger)
 import Service.Automation (Automation, nullAutomation)
 import Service.AutomationName (AutomationName (..))
 import Service.Automations.Gold (goldAutomation)
@@ -14,9 +14,10 @@ import Service.Automations.HTTP (httpAutomation)
 import Service.Automations.LuaScript (luaAutomation)
 import Service.Automations.StateManager (stateManagerAutomation)
 import Service.Env (Env)
+import Service.MQTT.Class (MQTTClient)
 
 findAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => AutomationName
   -> (UTCTime -> Automation m)
 findAutomation = \case

--- a/src/Service/Automations/Gold.hs
+++ b/src/Service/Automations/Gold.hs
@@ -14,7 +14,7 @@ import Data.Foldable (for_)
 import qualified Data.Text as T
 import Data.Time.Clock (UTCTime)
 import Network.MQTT.Client (Topic)
-import Service.App (Logger (..), findDeviceM, publish)
+import Service.App (Logger (..), debug, findDeviceM, info, publish)
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import Service.AutomationName (AutomationName (..))
@@ -34,7 +34,7 @@ basementStandingLampGroupId :: GroupId
 basementStandingLampGroupId = 1
 
 goldAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 goldAutomation ts =
@@ -46,7 +46,7 @@ goldAutomation ts =
     }
 
 cleanupAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 cleanupAutomation _broadcastChan = do
@@ -61,7 +61,7 @@ cleanupAutomation _broadcastChan = do
     publish lightStripTopic "{\"state\": \"OFF\"}"
 
 runAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 runAutomation broadcastChan = do
@@ -100,7 +100,7 @@ runAutomation broadcastChan = do
 
   where
     go
-      :: (Logger m, MonadReader (Env mc) m, MQTTClient mc, MonadUnliftIO m)
+      :: (Logger l, MonadReader (Env l mc) m, MQTTClient mc, MonadUnliftIO m)
       => Topic
       -> TChan Automation.Message
       -> m ()

--- a/src/Service/Automations/Gold.hs
+++ b/src/Service/Automations/Gold.hs
@@ -14,13 +14,14 @@ import Data.Foldable (for_)
 import qualified Data.Text as T
 import Data.Time.Clock (UTCTime)
 import Network.MQTT.Client (Topic)
-import Service.App (Logger (..), MonadMQTT (..), findDeviceM)
+import Service.App (Logger (..), findDeviceM, publish)
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import Service.AutomationName (AutomationName (..))
 import Service.Device (DeviceId, topicSet)
 import Service.Env (Env, daemonBroadcast)
 import Service.Group (GroupId)
+import Service.MQTT.Class (MQTTClient (..))
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import Service.MQTT.Messages.Lighting (Effect (..), effect', hex', mkHex, seconds, withTransition')
 import UnliftIO.Concurrent (threadDelay)
@@ -33,7 +34,7 @@ basementStandingLampGroupId :: GroupId
 basementStandingLampGroupId = 1
 
 goldAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 goldAutomation ts =
@@ -45,7 +46,7 @@ goldAutomation ts =
     }
 
 cleanupAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 cleanupAutomation _broadcastChan = do
@@ -57,10 +58,10 @@ cleanupAutomation _broadcastChan = do
     let lightStripTopic = lightStrip' ^. topicSet
 
     info "turning led strip off"
-    publishMQTT lightStripTopic "{\"state\": \"OFF\"}"
+    publish lightStripTopic "{\"state\": \"OFF\"}"
 
 runAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 runAutomation broadcastChan = do
@@ -84,29 +85,29 @@ runAutomation broadcastChan = do
     let lightStripTopic = lightStrip' ^. topicSet
 
     debug "turning on"
-    publishMQTT lightStripTopic "{\"state\": \"ON\"}"
+    publish lightStripTopic "{\"state\": \"ON\"}"
 
     debug "setting color to orange"
-    publishMQTT lightStripTopic (hex' "be9fc1")
+    publish lightStripTopic (hex' "be9fc1")
 
     liftIO $ threadDelay (seconds 2)
 
     debug "setting color to pink with 3 second transition"
-    publishMQTT lightStripTopic (withTransition' 3 $ mkHex "F97C00")
+    publish lightStripTopic (withTransition' 3 $ mkHex "F97C00")
 
     debug "starting breathe loop"
     go lightStripTopic broadcastChan
 
   where
     go
-      :: (Logger m, MonadReader Env m, MonadMQTT m, MonadUnliftIO m)
+      :: (Logger m, MonadReader (Env mc) m, MQTTClient mc, MonadUnliftIO m)
       => Topic
       -> TChan Automation.Message
       -> m ()
     go lightStripTopic broadcastChan' = do
       liftIO $ threadDelay $ seconds 60
       debug "Gold: breathe"
-      publishMQTT lightStripTopic $ effect' Breathe
+      publish lightStripTopic $ effect' Breathe
       --
       -- For now, this and GoldMsg below are just here to remind me
       -- how to create and use per-Automation message types...actually,

--- a/src/Service/Automations/HTTP.hs
+++ b/src/Service/Automations/HTTP.hs
@@ -15,7 +15,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WebSockets as WaiWs
 import Network.Wai.Middleware.Static (addBase, staticPolicy)
 import qualified Network.WebSockets as WS
-import Service.App (Logger (..))
+import Service.App (Logger (..), debug)
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import qualified Service.AutomationName as AutomationName
@@ -26,7 +26,7 @@ import UnliftIO.STM (TChan, TVar, readTVarIO)
 import Web.Scotty (file, get, middleware, raw, scottyApp, setHeader)
 
 httpAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 httpAutomation ts =
@@ -38,14 +38,14 @@ httpAutomation ts =
     }
 
 mkCleanupAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => (TChan Automation.Message -> m ())
 mkCleanupAutomation = \_broadcastChan -> do
   debug $ "Starting Cleanup: HTTP"
 
 
 mkRunAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => (TChan Automation.Message -> m ())
 mkRunAutomation = \_broadcastChan -> do
   debug $ "Beginning run of HTTP"

--- a/src/Service/Automations/HTTP.hs
+++ b/src/Service/Automations/HTTP.hs
@@ -15,17 +15,18 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WebSockets as WaiWs
 import Network.Wai.Middleware.Static (addBase, staticPolicy)
 import qualified Network.WebSockets as WS
-import Service.App (Logger (..), MonadMQTT (..))
+import Service.App (Logger (..))
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import qualified Service.AutomationName as AutomationName
 import Service.Env (Env, devicesRawJSON)
+import Service.MQTT.Class (MQTTClient)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.STM (TChan, TVar, readTVarIO)
 import Web.Scotty (file, get, middleware, raw, scottyApp, setHeader)
 
 httpAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 httpAutomation ts =
@@ -37,14 +38,14 @@ httpAutomation ts =
     }
 
 mkCleanupAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => (TChan Automation.Message -> m ())
 mkCleanupAutomation = \_broadcastChan -> do
   debug $ "Starting Cleanup: HTTP"
 
 
 mkRunAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => (TChan Automation.Message -> m ())
 mkRunAutomation = \_broadcastChan -> do
   debug $ "Beginning run of HTTP"

--- a/src/Service/Automations/LuaScript.hs
+++ b/src/Service/Automations/LuaScript.hs
@@ -33,14 +33,15 @@ import Network.HTTP.Client (httpLbs, newManager, parseRequest, responseBody, res
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.MQTT.Topic (mkTopic, unTopic)
 import qualified Service.App as App
-import Service.App (Logger (..), MonadMQTT (..))
+import Service.App (Logger (..))
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import qualified Service.AutomationName as AutomationName
 import Service.Device (Device, DeviceId, toLuaDevice, topicSet)
-import Service.Env (Env, LogLevel (Debug), LoggerVariant (..), MQTTClientVariant (..), config,
+import Service.Env (Env, LogLevel (Debug), LoggerVariant (..), config,
                     daemonBroadcast, devices, groups, logger, luaScriptPath, mqttClient)
 import Service.Group (Group, GroupId, memberId, members, toLuaGroup)
+import Service.MQTT.Class (MQTTClient (..))
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import Service.MQTT.Messages.Lighting (mkRGB)
 import qualified Service.TimeHelpers as TH
@@ -51,7 +52,7 @@ import UnliftIO.STM (TChan, TVar, atomically, dupTChan, newBroadcastTChan, readT
                      readTVarIO, writeTChan)
 
 luaAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => FilePath
   -> UTCTime
   -> Automation m
@@ -64,7 +65,7 @@ luaAutomation filepath ts =
     }
 
 mkCleanupAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => FilePath
   -> (TChan Automation.Message -> m ())
 mkCleanupAutomation filepath = \_broadcastChan -> do
@@ -81,7 +82,7 @@ mkCleanupAutomation filepath = \_broadcastChan -> do
 
   luaStatusString <- liftIO . Lua.unsafeRunWith luaState $ do
     Lua.openlibs -- load the default Lua packages
-    loadDSL filepath logger' mqttClient' daemonBroadcast' devices' groups'
+    loadAPI filepath logger' mqttClient' daemonBroadcast' devices' groups'
     loadScript luaScriptPath' filepath *> Lua.callTrace 0 0
     callWhenExists "cleanup"
 
@@ -105,7 +106,7 @@ mkCleanupAutomation filepath = \_broadcastChan -> do
 type StatusMsg = String
 
 mkRunAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => FilePath
   -> (TChan Automation.Message -> m ())
 mkRunAutomation filepath = \_broadcastChan -> do
@@ -129,7 +130,7 @@ mkRunAutomation filepath = \_broadcastChan -> do
   luaStatusString <- handle (\e -> pure . show $ (e :: Lua.Exception)) $
     liftIO . Lua.unsafeRunWith luaState $ do
       Lua.openlibs -- load the default Lua packages
-      loadDSL filepath logger' mqttClient' daemonBroadcast' devices' groups'
+      loadAPI filepath logger' mqttClient' daemonBroadcast' devices' groups'
       -- TODO this needs error handling
       loadScript luaScriptPath' filepath *> Lua.callTrace 0 0
 
@@ -169,15 +170,16 @@ callWhenExists fnName = do
     Lua.TypeFunction -> Just <$> Lua.callTrace 0 0
     _                -> pure Nothing
 
-loadDSL
-  :: FilePath
+loadAPI
+  :: (MQTTClient mqttClient)
+  => FilePath
   -> LoggerVariant
-  -> MQTTClientVariant
+  -> mqttClient
   -> TChan Daemon.Message
   -> TVar (HashMap DeviceId Device)
   -> TVar (HashMap GroupId Group)
   -> Lua.LuaE Lua.Exception ()
-loadDSL filepath logger' mqttClient' daemonBroadcast' devices' groups' = do
+loadAPI filepath logger' mqttClient' daemonBroadcast' devices' groups' = do
   for_ functions $ \(fn, fnName) ->
     pushDocumentedFunction fn *> Lua.setglobal fnName
 
@@ -271,7 +273,7 @@ loadDSL filepath logger' mqttClient' daemonBroadcast' devices' groups' = do
 
     publishImpl :: Text -> ByteString -> Lua.LuaE Lua.Exception ()
     publishImpl topic msg = liftIO $
-      App.publish (fromMaybe "" $ mkTopic topic) msg mqttClient'
+      publishMQTT mqttClient' (fromMaybe "" $ mkTopic topic) msg
 
     publish :: DocumentedFunction Lua.Exception
     publish =

--- a/src/Service/Automations/StateManager.hs
+++ b/src/Service/Automations/StateManager.hs
@@ -14,7 +14,7 @@ import Control.Monad.Reader (MonadReader)
 import qualified Data.Aeson as Aeson
 import Data.Time.Clock (UTCTime)
 import qualified Data.Vector as V
-import Service.App (Logger (..))
+import Service.App (Logger (..), info)
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import Service.AutomationName (AutomationName (..))
@@ -24,7 +24,7 @@ import qualified Service.StateStore as StateStore
 import UnliftIO.STM (TChan, atomically, readTChan)
 
 stateManagerAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 stateManagerAutomation ts =
@@ -36,14 +36,14 @@ stateManagerAutomation ts =
     }
 
 cleanupAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 cleanupAutomation _broadcastChan = do
   info "Shutting down StateManager"
 
 runAutomation
-  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 runAutomation broadcastChan = do
@@ -53,7 +53,7 @@ runAutomation broadcastChan = do
 
   where
     go
-      :: (Logger m, MonadReader (Env mc) m, MQTTClient mc, MonadUnliftIO m)
+      :: (Logger l, MonadReader (Env l mc) m, MQTTClient mc, MonadUnliftIO m)
       => FilePath
       -> m ()
     go dbPath' = do

--- a/src/Service/Automations/StateManager.hs
+++ b/src/Service/Automations/StateManager.hs
@@ -14,16 +14,17 @@ import Control.Monad.Reader (MonadReader)
 import qualified Data.Aeson as Aeson
 import Data.Time.Clock (UTCTime)
 import qualified Data.Vector as V
-import Service.App (Logger (..), MonadMQTT (..))
+import Service.App (Logger (..))
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (..))
 import Service.AutomationName (AutomationName (..))
 import Service.Env (Env, config, dbPath)
+import Service.MQTT.Class (MQTTClient (..))
 import qualified Service.StateStore as StateStore
 import UnliftIO.STM (TChan, atomically, readTChan)
 
 stateManagerAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => UTCTime
   -> Automation m
 stateManagerAutomation ts =
@@ -35,14 +36,14 @@ stateManagerAutomation ts =
     }
 
 cleanupAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 cleanupAutomation _broadcastChan = do
   info "Shutting down StateManager"
 
 runAutomation
-  :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => TChan Automation.Message
   -> m ()
 runAutomation broadcastChan = do
@@ -52,7 +53,7 @@ runAutomation broadcastChan = do
 
   where
     go
-      :: (Logger m, MonadReader Env m, MonadMQTT m, MonadUnliftIO m)
+      :: (Logger m, MonadReader (Env mc) m, MQTTClient mc, MonadUnliftIO m)
       => FilePath
       -> m ()
     go dbPath' = do

--- a/src/Service/Daemon.hs
+++ b/src/Service/Daemon.hs
@@ -28,20 +28,22 @@ import Data.Traversable (for)
 import qualified Data.Vector as V
 import GHC.Conc (ThreadStatus (..), threadStatus)
 import Network.MQTT.Topic (Topic)
-import Service.App (Logger (..), MonadMQTT (..))
+import qualified Service.App as App
+import Service.App (Logger (..))
 import qualified Service.Automation as Automation
 import Service.Automation (Automation (_name), ClientMsg (..), Message (..))
 import Service.AutomationName (AutomationName (..), parseAutomationNameText,
                                serializeAutomationName)
 import Service.Automations (findAutomation)
 import qualified Service.Device as Device
-import Service.Env (AutomationEntry, Env, Registrations, RestartConditions (..), ThreadMap,
-                    appCleanup, automationBroadcast, automationServiceTopic, config,
+import Service.Env (AutomationEntry, Env, Registrations, RestartConditions (..),
+                    ThreadMap, appCleanup, automationBroadcast, automationServiceTopic, config,
                     daemonBroadcast, dbPath, deviceRegistrations, devices, devicesRawJSON,
                     groupRegistrations, groups, groupsRawJSON, loadedDevices, loadedGroups,
                     messageChan, mqttConfig, mqttDispatch, notAlreadyRestarted, restartConditions,
                     scheduledJobs, startupMessages, subscriptions)
 import qualified Service.Group as Group
+import Service.MQTT.Class (MQTTClient)
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import Service.MQTT.Messages.Daemon (AutomationSchedule)
 import Service.MQTT.Status (encodeAutomationStatus)
@@ -54,7 +56,7 @@ import UnliftIO.STM (STM, TChan, TVar, atomically, dupTChan, modifyTVar', newTVa
                      readTVar, readTVarIO, writeTChan, writeTVar)
 
 run
-  :: (Logger m, MonadReader Env m, MonadMQTT m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => m ()
 run = do
   threadMapTV <- newTVarIO M.empty
@@ -68,7 +70,7 @@ run = do
 -- module anyways, so it's probably for the best regardless.
 --
 run'
-  :: (Logger m, MonadReader Env m, MonadMQTT m, MonadUnliftIO m)
+  :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
   => TVar (ThreadMap m)
   -> m ()
 run' threadMapTV = do
@@ -193,7 +195,7 @@ run' threadMapTV = do
       fromMaybe [] . sequence . fmap (decode . LBS.fromStrict . snd)
 
     cleanupAutomations
-      :: (Logger m, MonadIO m, MonadReader Env m, MonadUnliftIO m)
+      :: (Logger m, MonadIO m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
       => IO ()
       -> TVar (ThreadMap m)
       -> m ()
@@ -205,7 +207,7 @@ run' threadMapTV = do
       liftIO appCleanup'
 
     cleanDeadAutomations
-      :: (MonadIO m, MonadMQTT m, MonadReader Env m) => TVar (ThreadMap m) -> m ()
+      :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => TVar (ThreadMap m) -> m ()
     cleanDeadAutomations threadMapTV' = do
       threadMap <- atomically $ readTVar threadMapTV'
       cleanupAutoNames <- liftIO $ foldMap'
@@ -220,7 +222,7 @@ run' threadMapTV = do
       let cleanedTM = foldl' (flip M.delete) threadMap cleanupAutoNames
       atomically $ writeTVar threadMapTV' cleanedTM
 
-    tryRestoreRunningAutomations :: (MonadIO m, MonadReader Env m) => m ()
+    tryRestoreRunningAutomations :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => m ()
     tryRestoreRunningAutomations = do
       rc <- view restartConditions
       rc' <- atomically . readTVar $ rc
@@ -235,7 +237,7 @@ run' threadMapTV = do
         _ -> pure ()
 
     initializeAndRunAutomation
-      :: (Logger m, MonadMQTT m, MonadReader Env m, MonadUnliftIO m)
+      :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
       => TVar (ThreadMap m)
       -> AutomationName
       -> m ()
@@ -279,7 +281,7 @@ run' threadMapTV = do
           pure $ snd <$> mPriorAutomation
 
     stopAutomation
-      :: (Logger m, MonadReader Env m, MonadUnliftIO m)
+      :: (Logger m, MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m)
       => TVar (ThreadMap m)
       -> AutomationName
       -> m ()
@@ -317,14 +319,14 @@ run' threadMapTV = do
           traverse
             (\bc -> writeTChan bc (object [("shutdownMessage", Aeson.Bool True)]))
 
-    signalRunningStateUpdate :: (MonadIO m, MonadReader Env m) => TVar (ThreadMap m) -> m ()
+    signalRunningStateUpdate :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => TVar (ThreadMap m) -> m ()
     signalRunningStateUpdate threadMapTV' = do
       runningAutos <- M.keys <$> (atomically . readTVar $ threadMapTV')
       sendClientMsg StateManager $ ValueMsg $
         Aeson.Array . V.fromList $ Aeson.String . serializeAutomationName <$> runningAutos
 
     publishUpdatedStatus
-      :: (MonadIO m, MonadMQTT m, MonadReader Env m) => TVar (ThreadMap m) -> m ()
+      :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => TVar (ThreadMap m) -> m ()
     publishUpdatedStatus threadMapTV' = do
       automationServiceTopic' <- view $ config . mqttConfig . automationServiceTopic
       deviceRegs <- view deviceRegistrations
@@ -336,17 +338,17 @@ run' threadMapTV = do
         deviceRegs' <- readTVar deviceRegs
         groupRegs' <- readTVar groupRegs
         pure $ encodeAutomationStatus running scheduled' deviceRegs' groupRegs'
-      publishMQTT automationServiceTopic' statusMsg
+      App.publish automationServiceTopic' statusMsg
 
     sendClientMsg
-      :: (MonadIO m, MonadReader Env m) => AutomationName -> ClientMsg -> m ()
+      :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => AutomationName -> ClientMsg -> m ()
     sendClientMsg automationName msg = do
       automationBroadcast' <- view automationBroadcast
       atomically . writeTChan automationBroadcast' $
         Client automationName msg
 
     runScheduledMessage
-      :: (Logger m, MonadIO m, MonadReader Env m)
+      :: (Logger m, MonadIO m, MQTTClient mc, MonadReader (Env mc) m)
       => Daemon.JobId
       -> Daemon.Message
       -> AutomationSchedule
@@ -390,14 +392,14 @@ run' threadMapTV = do
           warn
             "Received multiple ThreadIds back when running execSchedule, all have been cancelled."
 
-    signalScheduledStateUpdate :: (MonadIO m, MonadReader Env m) => m ()
+    signalScheduledStateUpdate :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => m ()
     signalScheduledStateUpdate = do
       scheduledJobs' <- readTVarIO =<< view scheduledJobs
       sendClientMsg StateManager $ ByteStringMsg $
         flip M.foldMapWithKey scheduledJobs' $ \jobId' (sched, msg, _threadId) ->
           [SBS.concat . LBS.toChunks . encode $ Daemon.Schedule jobId' sched msg]
 
-    unscheduleJob :: (MonadIO m, MonadReader Env m) => Daemon.JobId -> m ()
+    unscheduleJob :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => Daemon.JobId -> m ()
     unscheduleJob jobId = do
       scheduledJobs' <- view scheduledJobs
       mPriorThreadId <- atomically $ do
@@ -408,13 +410,13 @@ run' threadMapTV = do
       for_ mPriorThreadId killThread
 
     updateRestartConditionsSet
-      :: (MonadIO m, MonadReader Env m) => Lens' RestartConditions Bool -> Bool -> m ()
+      :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => Lens' RestartConditions Bool -> Bool -> m ()
     updateRestartConditionsSet field conditionState = do
       restartConditions' <- view restartConditions
       atomically $ modifyTVar' restartConditions' $ field .~ conditionState
 
     addRegisteredResource
-      :: (MonadReader Env m, MonadUnliftIO m, Hashable k)
+      :: (MQTTClient mc, MonadReader (Env mc) m, MonadUnliftIO m, Hashable k)
       => k
       -> AutomationName
       -> TVar (HashMap k (NonEmpty AutomationName))
@@ -424,7 +426,7 @@ run' threadMapTV = do
         M.insertWith (<>) resourceId $ newAutoName :| []
 
     deregisterDevicesAndGroups
-      :: (Logger m, MonadIO m, MonadReader Env m) => AutomationName -> m ()
+      :: (Logger m, MonadIO m, MQTTClient mc, MonadReader (Env mc) m) => AutomationName -> m ()
     deregisterDevicesAndGroups automationName = do
       deviceRegs <- view deviceRegistrations
       groupRegs <- view groupRegistrations
@@ -446,7 +448,7 @@ run' threadMapTV = do
             regs'
 
     subscribe
-      :: (MonadIO m, MonadMQTT m, MonadReader Env m)
+      :: (MonadIO m, MQTTClient mc, MonadReader (Env mc) m)
       => AutomationName
       -> Topic
       -> TChan Value
@@ -459,7 +461,7 @@ run' threadMapTV = do
           M.insertWith (<>) topic $ mkDefaultTopicMsgAction :| []
         modifyTVar' subscriptions' $
           M.insertWith (<>) automationName $ listenerBcastChan :| []
-      subscribeMQTT topic
+      App.subscribe topic
 
       where
         mkDefaultTopicMsgAction = \topicMsg ->

--- a/src/Service/Env/Config.hs
+++ b/src/Service/Env/Config.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Service.Env.Config
+  ( Config(..)
+  , LogLevel(..)
+  , MQTTConfig(..)
+  , automationServiceTopic
+  , caCertPath
+  , clientCertPath
+  , clientKeyPath
+  , configDecoder
+  , dbPath
+  , logFilePath
+  , logLevel
+  , luaScriptPath
+  , mqttConfig
+  , mqttConfigDecoder
+  , statusTopic
+  , uri
+  , uriDecoder
+  )
+where
+
+import Control.Lens (makeFieldsNoPrefix, (<&>))
+import Data.Maybe (fromMaybe)
+import Dhall (Decoder, FromDhall (..), Generic, auto, field, record, strictText, string)
+import Network.MQTT.Topic (Topic)
+import Network.URI (URI, nullURI, parseURI)
+import Service.MQTT.Topic (parseTopic)
+
+data LogLevel = Debug | Info | Warn | Error
+  deriving (Generic, Show, Eq, Ord)
+
+instance FromDhall LogLevel
+
+data MQTTConfig = MQTTConfig
+  { _uri                    :: URI
+  , _automationServiceTopic :: Topic
+  , _statusTopic            :: Topic
+  , _caCertPath             :: Maybe FilePath
+  , _clientCertPath         :: Maybe FilePath
+  , _clientKeyPath          :: Maybe FilePath
+  }
+  deriving (Generic, Show)
+
+makeFieldsNoPrefix ''MQTTConfig
+
+mqttConfigDecoder :: Decoder MQTTConfig
+mqttConfigDecoder =
+  record
+    ( MQTTConfig
+        <$> field "uri" uriDecoder
+        <*> field "automationServiceTopic" (strictText <&> parseTopic)
+        <*> field "statusTopic" (strictText <&> parseTopic)
+        <*> field "caCertPath" auto
+        <*> field "clientCertPath" auto
+        <*> field "clientKeyPath" auto
+    )
+
+-- TODO maybe should at least notify the user somehow if this happens?
+-- Although I guess it should probably be an initialization check
+-- vs. doing that here
+uriDecoder :: Decoder URI
+uriDecoder = string <&> fromMaybe nullURI . parseURI
+
+data Config = Config
+  { _mqttConfig    :: MQTTConfig
+  , _logFilePath   :: FilePath
+  , _logLevel      :: LogLevel
+  , _luaScriptPath :: FilePath
+  , _dbPath        :: FilePath
+  }
+  deriving (Generic, Show)
+
+makeFieldsNoPrefix ''Config
+
+configDecoder :: Decoder Config
+configDecoder =
+  record
+    ( Config
+        <$> field "mqttBroker" mqttConfigDecoder
+        <*> field "logFilePath" string
+        <*> field "logLevel" auto
+        <*> field "luaScriptPath" string
+        <*> field "dbPath" string
+    )

--- a/src/Service/MQTT/Class.hs
+++ b/src/Service/MQTT/Class.hs
@@ -1,0 +1,19 @@
+module Service.MQTT.Class
+ ( MQTTClient (..)
+ )
+where
+
+import Control.Monad (void)
+import Data.ByteString.Lazy (ByteString)
+import qualified Network.MQTT.Client as MQTT
+import Network.MQTT.Topic (Topic, toFilter)
+
+class MQTTClient a where
+  publishMQTT :: a -> Topic -> ByteString -> IO ()
+  subscribeMQTT :: a -> Topic -> IO ()
+
+instance MQTTClient (MQTT.MQTTClient) where
+  publishMQTT mc topic msg = MQTT.publish mc topic msg False
+  subscribeMQTT mc topic =
+    -- handle response properly!
+    void $ MQTT.subscribe mc [(toFilter topic, MQTT.subOptions)] []

--- a/test/Test/Integration/Service/Daemon.hs
+++ b/test/Test/Integration/Service/Daemon.hs
@@ -25,17 +25,17 @@ import Network.MQTT.Topic (mkTopic)
 import Safe (headMay)
 import Service.Automation (name)
 import Service.AutomationName (AutomationName (..), parseAutomationName, serializeAutomationName)
-import Service.Env (LoggerVariant (..), RestartConditions (..),
-                    automationServiceTopic, config, daemonBroadcast, dbPath, deviceRegistrations,
-                    groupRegistrations, logger, mqttClient, mqttConfig, mqttDispatch,
-                    restartConditions, scheduledJobs)
+import Service.Env (RestartConditions (..), automationServiceTopic, config, daemonBroadcast, dbPath,
+                    deviceRegistrations, groupRegistrations, logger, mqttClient, mqttConfig,
+                    mqttDispatch, restartConditions, scheduledJobs)
 import Service.MQTT.Class (MQTTClient)
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import qualified Service.StateStore as StateStore
 import System.Environment (setEnv)
 import Test.Hspec (Spec, around, expectationFailure, it, shouldBe, xit)
-import Test.Integration.Service.DaemonTestHelpers (TestMQTTClient (..), initAndCleanup,
-                                                   testWithAsyncDaemon, waitUntilEq, waitUntilEqSTM)
+import Test.Integration.Service.DaemonTestHelpers (TestLogger (..), TestMQTTClient (..),
+                                                   initAndCleanup, testWithAsyncDaemon, waitUntilEq,
+                                                   waitUntilEqSTM)
 import UnliftIO.Async (asyncThreadId)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.STM (atomically, readTChan, readTVar, readTVarIO, writeTChan, writeTVar)
@@ -125,7 +125,7 @@ luaScriptSpecs = do
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
-          (QLogger qLogger) = env ^. logger
+          (TestLogger qLogger) = env ^. logger
           expectedLogEntry = "Debug: LuaScript testBroken finished with status '\"Lua exception: attempt to call a string value\\nstack traceback:\"'."
 
         atomically $ writeTChan daemonBroadcast' $ Daemon.Start (LuaScript "testBroken")
@@ -187,7 +187,7 @@ luaScriptSpecs = do
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
-          (QLogger qLogger) = env ^. logger
+          (TestLogger qLogger) = env ^. logger
           mqttDispatch' = env ^. mqttDispatch
           Just topic = mkTopic "testTopic"
           expectedLogEntry = "Debug: testSubscribe: Msg: hey"
@@ -287,7 +287,7 @@ luaScriptSpecs = do
 
         let
           daemonBroadcast' = env ^. daemonBroadcast
-          (QLogger qLogger) = env ^. logger
+          (TestLogger qLogger) = env ^. logger
 
         atomically $ writeTChan daemonBroadcast' $ Daemon.Start (LuaScript "testSunEvents")
 

--- a/test/Test/Integration/Service/Daemon.hs
+++ b/test/Test/Integration/Service/Daemon.hs
@@ -15,6 +15,7 @@ import qualified Data.ByteString.Char8 as SBS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (for_)
 import qualified Data.HashMap.Strict as M
+import Data.List (null)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Maybe (fromJust, fromMaybe)
 import Data.Text (Text)
@@ -24,16 +25,17 @@ import Network.MQTT.Topic (mkTopic)
 import Safe (headMay)
 import Service.Automation (name)
 import Service.AutomationName (AutomationName (..), parseAutomationName, serializeAutomationName)
-import Service.Env (LoggerVariant (..), MQTTClientVariant (..), RestartConditions (..),
+import Service.Env (LoggerVariant (..), RestartConditions (..),
                     automationServiceTopic, config, daemonBroadcast, dbPath, deviceRegistrations,
                     groupRegistrations, logger, mqttClient, mqttConfig, mqttDispatch,
                     restartConditions, scheduledJobs)
+import Service.MQTT.Class (MQTTClient)
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import qualified Service.StateStore as StateStore
 import System.Environment (setEnv)
 import Test.Hspec (Spec, around, expectationFailure, it, shouldBe, xit)
-import Test.Integration.Service.DaemonTestHelpers (initAndCleanup, testWithAsyncDaemon, waitUntilEq,
-                                                   waitUntilEqSTM)
+import Test.Integration.Service.DaemonTestHelpers (TestMQTTClient (..), initAndCleanup,
+                                                   testWithAsyncDaemon, waitUntilEq, waitUntilEqSTM)
 import UnliftIO.Async (asyncThreadId)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.STM (atomically, readTChan, readTVar, readTVarIO, writeTChan, writeTVar)
@@ -243,7 +245,7 @@ luaScriptSpecs = do
           logs <- readTVarIO qLogger
           pure . fromMaybe "" . headMay . filter (== expectedLogEntry) $ logs
 
-  -- flaky
+  -- flaky?
   around initAndCleanup $ do
     it "removes Device and Group Registration entries upon cleanup" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
@@ -276,6 +278,7 @@ luaScriptSpecs = do
         groupRegs' <- readTVarIO groupRegistrations'
         M.lookup groupId groupRegs' `shouldBe` Nothing
 
+  -- flaky
   around initAndCleanup $ do
     xit "retrieves dates for Sun events (rise & set)" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
@@ -661,7 +664,7 @@ statusMessageSpecs = do
         let
           daemonBroadcast' = env ^. daemonBroadcast
           automationServiceTopic' = env ^. config . mqttConfig . automationServiceTopic
-          (TVClient topicMapTV) = env ^. mqttClient
+          (TestMQTTClient topicMapTV) = env ^. mqttClient
 
         atomically $ writeTChan daemonBroadcast' Daemon.Status
 

--- a/test/Test/Integration/Service/DaemonTestHelpers.hs
+++ b/test/Test/Integration/Service/DaemonTestHelpers.hs
@@ -1,5 +1,6 @@
 module Test.Integration.Service.DaemonTestHelpers
-  ( initAndCleanup
+  ( TestMQTTClient(..)
+  , initAndCleanup
   , testWithAsyncDaemon
   , waitUntilEq
   , waitUntilEqSTM
@@ -7,22 +8,35 @@ module Test.Integration.Service.DaemonTestHelpers
   where
 
 import Control.Lens (view, (%~), (&), (^.))
+import Data.ByteString.Lazy (ByteString)
+import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as M
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
+import Network.MQTT.Client (Topic)
 import qualified Service.App as App
+import Service.App ()
 import qualified Service.Daemon as Daemon
 import qualified Service.Device as Device
 import qualified Service.Env as Env
-import Service.Env (Env, LoggerVariant (QLogger), MQTTClientVariant (..), appCleanup, config,
+import Service.Env (Env, LoggerVariant (QLogger), appCleanup, config,
                     daemonBroadcast, dbPath, devices, groups)
 import qualified Service.Group as Group
+import Service.MQTT.Class (MQTTClient (..))
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import Test.Helpers (loadTestDevices, loadTestGroups)
 import Test.Hspec (Expectation, shouldBe)
 import UnliftIO.Async (withAsync)
 import UnliftIO.Exception (bracket)
-import UnliftIO.STM (STM, TChan, TVar, atomically, dupTChan, newTVarIO)
+import UnliftIO.STM (STM, TChan, TVar, atomically, dupTChan, modifyTVar', newTVarIO)
+
+newtype TestMQTTClient = TestMQTTClient (TVar (HashMap Topic ByteString))
+
+instance MQTTClient TestMQTTClient where
+  publishMQTT (TestMQTTClient mc) topic msg =
+    atomically $ modifyTVar' mc $ \mqttMsgs ->
+      M.insert topic msg mqttMsgs
+  subscribeMQTT (TestMQTTClient _mc) _topic = pure ()
 
 testConfigFilePath :: FilePath
 testConfigFilePath = "test/config.dhall"
@@ -35,7 +49,7 @@ testConfigFilePath = "test/config.dhall"
 -- initialization exclusively through configuration alone, insofar as
 -- it even needs to be distinct.
 --
-initAndCleanup :: (Env -> IO ()) -> IO ()
+initAndCleanup :: ((Env TestMQTTClient) -> IO ()) -> IO ()
 initAndCleanup runTests = bracket
   (do
       env <- Env.initialize testConfigFilePath mkLogger mkMQTTClient
@@ -64,7 +78,7 @@ initAndCleanup runTests = bracket
 
     mkMQTTClient _config _loggerVariant _mqttDispatch = do
       fauxMQTTClient <- newTVarIO M.empty
-      pure (TVClient fauxMQTTClient, pure ())
+      pure (TestMQTTClient fauxMQTTClient, pure ())
 
 -- |
 -- | Takes a function accepting a bunch of state and returning an
@@ -92,13 +106,14 @@ initAndCleanup runTests = bracket
 -- @
 --
 testWithAsyncDaemon
-  ::
-    (  Env
-    -> TVar (Daemon.ThreadMap App.AutomationService)
+  :: (MQTTClient mc)
+  =>
+    (  (Env mc)
+    -> TVar (Daemon.ThreadMap (App.AutomationService mc))
     -> TChan Daemon.Message
     -> Expectation
     )
-  -> Env
+  -> (Env mc)
   -> Expectation
 testWithAsyncDaemon test env = do
   let daemonBroadcast' = env ^. daemonBroadcast


### PR DESCRIPTION
I finally figured out how to remove the [`LoggerVariant`](https://github.com/ddellacosta/automation-service/pull/17/files#diff-6a0381c769059acd18f33cbf36739389932b9f4cbd7609efcb68c0de761a6ba7L140) and [`MQTTClientVariant`](https://github.com/ddellacosta/automation-service/pull/17/files#diff-6a0381c769059acd18f33cbf36739389932b9f4cbd7609efcb68c0de761a6ba7L145) abominations. While the existence of a type class for these resources at all probably implies testing-related boilerplate, with the changes in this PR, [the test-specific logic is actually in the test helper code](https://github.com/ddellacosta/automation-service/pull/17/files#diff-fd90ac3a28125a2fe8e4d4b28814ab95c5581b2c6409c2fb4d0c8af01c970abbR35-R49) vs. in application code ([yuck](https://github.com/ddellacosta/automation-service/pull/17/files#diff-64e5f16458e4015cb947ca01b7b88b8076d03048d2bd1863fa94e6c954cf23a7L70-L125)), and this removes some noise from the `Service.App` code too. A tradeoff with this approach is more [type sig boilerplate](https://github.com/ddellacosta/automation-service/pull/17/files#diff-ed2d50c61bf9d079322ac022f0663ae69e9e7d33c9b2087871dcce64959baa39R37), what with the two new arguments to `Env`, but this isn't a big deal with search and replace, and adds more useful information to the codebase, I guess?

This also includes some drive-by refactoring, [splitting Dhall config logic out of `Env`](https://github.com/ddellacosta/automation-service/pull/17/files#diff-479f244f3e7230fc6c1d6e1c1493d9ff5b7b1ef8a35f7c80502fcaa8bdab9ccdR1). I also renamed `loadDSL` in `Service.Automations.LuaScript` to `loadAPI`, which I've been meaning to do for a while.