### PR TITLE
Zigbee2MQTT Devices need to actually be categorized

### DIFF
--- a/ui/src/AutomationService/Device.purs
+++ b/ui/src/AutomationService/Device.purs
@@ -14,18 +14,25 @@ module AutomationService.Device
   , decodeDevices
   , details
   , deviceTopic
+  , deviceType
   , getTopic
   , setDetails
   , setTopic
   )
 where
 
-import AutomationService.Exposes (CapType(..), Exposes, FeatureType(..), decodeExposes)
+import Debug (trace, traceM)
+
+import AutomationService.Exposes (Capability, CapType(..), Exposes, FeatureType(..), decodeExposes)
+import Control.Alt ((<|>))
+import Control.Monad (when)
 import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, toArray)
 import Data.Argonaut.Decode.Combinators ((.:), (.:?))
-import Data.Array (filter)
+import Data.Array (filter, null)
 import Data.Array.NonEmpty (fromArray, head, sort)
+import Data.Array.NonEmpty as NonEmpty
 import Data.Either (Either(..), isRight)
+import Data.Foldable (for_)
 import Data.Generic.Rep (class Generic)
 import Data.Lens (Lens, Lens', lens')
 import Data.Lens.Record (prop)
@@ -34,7 +41,7 @@ import Data.Maybe (Maybe(..))
 import Data.Show.Generic (genericShow)
 import Data.Traversable (for, sequence)
 import Data.Tuple (Tuple(..))
-import Prelude (class Eq, class Ord, class Show, bind, flip, map, pure, ($), (<$>), (<>), (=<<))
+import Prelude (class Eq, class Ord, class Show, bind, discard, flip, map, not, pure, show, (<<<), ($), (<$>), (<>), (=<<), (==), (&&), (||))
 import Type.Proxy (Proxy(..))
 
 type DeviceId = String
@@ -98,13 +105,13 @@ _exposes = prop (Proxy :: Proxy "exposes")
 -- capabilities of the Device (which for now just means the stuff
 -- inside of DeviceDetails's exposes field, directly from
 -- https://www.zigbee2mqtt.io/guide/usage/exposes.html). The Device
--- constructors are modeled after Matter 1.2 spec Device types, and
+-- constructors are modeled after Matter 1.4 spec Device types, and
 -- I'll be adding them as I have use for them unless other people
 -- start using this for some reason and ask for it (or contribute it
 -- themselves).
 --
 -- In the future I hope that means both Matter devices as well as
--- ESPHome devices.
+-- ESPHome devices, however that could work.
 --
 
 --
@@ -118,17 +125,36 @@ _exposes = prop (Proxy :: Proxy "exposes")
 -- between features across device sets (e.g. Lights vs. Sensors vs.
 -- Switches vs. etc.) such that if we identify multiple possible
 -- Device types based on what comes back in Exposes, a sort will
--- always pop the most feature-full type to the top.
+-- always pop the most feature-full type to the top...but this may
+-- only work with lights...not sure yet. Other device types seem to
+-- have basically completely disjoint sets of distinguishing
+-- properties.
 --
--- We'll see if that assumption holds...
+-- In any case, a flat list like this has seemed to be the easiest to
+-- work with so far. Having a lot of structure here is hard to
+-- work with and maintain, and is not reflected in the Matter spec
+-- itself in any case.
 --
 data Device
   = ExtendedColorLight DeviceDetails
   | ColorTemperatureLight DeviceDetails
   | DimmableLight DeviceDetails
   | OnOffLight DeviceDetails
+  | ContactSensor DeviceDetails
+  | OccupancySensor DeviceDetails
   | WindowCovering DeviceDetails
   | UnknownDevice DeviceDetails
+
+deviceType :: Device -> String
+deviceType = case _ of
+  ExtendedColorLight _ -> "ExtendedColorLight"
+  ColorTemperatureLight _ -> "ColorTemperatureLight"
+  DimmableLight _ -> "DimmableLight"
+  OnOffLight _ -> "OnOffLight"
+  ContactSensor _ -> "ContactSensor"
+  OccupancySensor _ -> "OccupancySensor"
+  WindowCovering _ -> "WindowCovering"
+  UnknownDevice _ -> "UnknownDevice"
 
 type Devices = Map DeviceId Device
 
@@ -145,6 +171,8 @@ details = case _ of
   DimmableLight d -> d
   ColorTemperatureLight d -> d
   ExtendedColorLight d -> d
+  ContactSensor d -> d
+  OccupancySensor d -> d
   WindowCovering d -> d
   UnknownDevice d -> d
 
@@ -154,11 +182,26 @@ setDetails d = case _ of
   DimmableLight _ -> DimmableLight d
   ColorTemperatureLight _ -> ColorTemperatureLight d
   ExtendedColorLight _ -> ExtendedColorLight d
+  ContactSensor _ -> ContactSensor d
+  OccupancySensor _ -> OccupancySensor d
   WindowCovering _ -> WindowCovering d
   UnknownDevice _ -> UnknownDevice d
 
 _deviceDetails :: Lens' Device DeviceDetails
 _deviceDetails = lens' $ \d -> Tuple (details d) (flip setDetails d)
+
+-- okay I guess these go in here too
+
+deviceTopic :: String -> String
+deviceTopic name' = "zigbee2mqtt/" <> name'
+
+setTopic :: String -> String
+setTopic name' = deviceTopic name' <> "/set"
+
+getTopic :: String -> String
+getTopic name' = deviceTopic name' <> "/get"
+
+--
 
 decodeDevices :: Json -> Either JsonDecodeError (Array Device)
 decodeDevices devicesJson = do
@@ -171,32 +214,6 @@ decodeDevices devicesJson = do
     Nothing ->
       Left (UnexpectedValue devicesJson)
 
---
--- TODO: make this store failures on as granular a level as possible,
--- only failing at the level a decode fails (vs. now where any
--- failure breaks the entire decoding process), and then report
--- failures back and log
---
-
---   pure $ case isOnOffLight deviceDetails, isCover deviceDetails of
---     true, false -> OnOffLight deviceDetails
---     false, true -> WindowCovering deviceDetails
---     _, _ -> OnOffLight deviceDetails
---
---   where
---     isOnOffLight _deviceDetails = true
---     isCover _deviceDetails = false
---
-
-deviceTopic :: String -> String
-deviceTopic name' = "zigbee2mqtt/" <> name'
-
-setTopic :: String -> String
-setTopic name' = deviceTopic name' <> "/set"
-
-getTopic :: String -> String
-getTopic name' = deviceTopic name' <> "/get"
-
 decodeBaseDevice :: Json -> Exposes -> Either JsonDecodeError DeviceDetails
 decodeBaseDevice deviceJson exposes = do
   obj <- decodeJson deviceJson
@@ -206,6 +223,145 @@ decodeBaseDevice deviceJson exposes = do
   manufacturer <- obj .:? "manufacturer"
   model <- obj .:? "model_id"
   pure $ { id: id', name: name', category, manufacturer, model, exposes }
+
+hasCapabilities :: (Capability -> Boolean) -> Exposes -> Boolean
+hasCapabilities pred exposes =
+    not <<< null <<< NonEmpty.filter pred $ exposes
+
+mkDefaultDevice :: DeviceDetails -> Either JsonDecodeError Device
+mkDefaultDevice = Right <<< UnknownDevice
+
+--
+-- Matter Device Library Specification R1.4
+-- Chapter 4. Lighting Device Types
+--
+decodeLightDevice :: DeviceDetails -> Either JsonDecodeError Device
+decodeLightDevice baseDevice =
+  let
+    defaultDevice = mkDefaultDevice baseDevice
+
+    extendedColorLight =
+      if hasCapabilities
+           (\e -> e.type == Composite' && (e.name == "color_xy" || e.name == "hue"))
+           baseDevice.exposes then
+        Right <<< ExtendedColorLight $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not an ExtendedColorLight"
+
+    colorTemperatureLight =
+      if hasCapabilities
+           (\e -> e.type == Numeric' && e.name == "color_temp")
+           baseDevice.exposes then
+        Right <<< ColorTemperatureLight $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a ColorTemperatureLight"
+
+    dimmableLight =
+      if hasCapabilities
+           (\e -> e.type == Numeric' && e.name == "brightness")
+           baseDevice.exposes then
+        Right <<< DimmableLight $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not an DimmableLight"
+
+    onOffLight =
+      if hasCapabilities
+           (\e -> e.type == Binary')
+           baseDevice.exposes then
+        Right <<< OnOffLight $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not an OnOffLight"
+
+  in
+   --
+   -- It's probably worth noting that this actually depends on the
+   -- order that these are checked in (unlike other device subtype
+   -- decoding functions which are essentially all just based on
+   -- distinct predicate checks), as each lighting type tends to
+   -- subsume all the properties of the lighting types underneath it
+   -- in the hierarchy. E.g. all lights have an on/off switch
+   -- property, and all lights have brightness from DimmableLight
+   -- "and up."
+   --
+   extendedColorLight
+     <|> colorTemperatureLight
+     <|> dimmableLight
+     <|> onOffLight
+     <|> defaultDevice
+
+--
+-- Matter Device Library Specification R1.4
+-- Chapter 7. Sensor Device Types
+--
+decodeSensorDevice :: DeviceDetails -> Either JsonDecodeError Device
+decodeSensorDevice baseDevice =
+  let
+    defaultDevice = mkDefaultDevice baseDevice
+
+    --
+    -- unimplemented:
+    --
+    -- LightSensor
+    -- TemperatureSensor
+    -- PressureSensor
+    -- FlowSensor
+    -- HumiditySensor
+    -- OnOffSensor
+    -- SmokeCOAlarm
+    -- AirQualitySensor
+    -- WaterFreezeDetector
+    -- WaterLeakDetector
+    -- RainSensor
+    --
+
+    contactSensor =
+      if hasCapabilities
+           (\e -> e.type == Binary' && e.name == "contact")
+           baseDevice.exposes then
+        Right <<< ContactSensor $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a ContactSensor"
+
+    occupancySensor =
+      if hasCapabilities
+           (\e -> e.type == Binary' && e.name == "occupancy")
+           baseDevice.exposes then
+        Right <<< OccupancySensor $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a OccupancySensor"
+
+  in do
+   traceM $ baseDevice.name <> " - sensor device exposes: " <> show baseDevice.exposes
+   contactSensor <|> occupancySensor <|> defaultDevice
+
+--
+-- Matter Device Library Specification R1.4
+-- Chapter 8. Closure Device Types
+--
+decodeClosureDevice :: DeviceDetails -> Either JsonDecodeError Device
+decodeClosureDevice baseDevice =
+  let
+    defaultDevice = mkDefaultDevice baseDevice
+
+    --
+    -- unimplemented:
+    --
+    -- DoorLock
+    -- DoorLockController
+    -- WindowCoveringController
+    --
+
+    windowCovering =
+      if hasCapabilities
+           (\e -> e.type == Numeric' && e.name == "position")
+           baseDevice.exposes then
+        Right <<< WindowCovering $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a WindowCovering"
+
+  in do
+   traceM $ baseDevice.name <> " - closure device exposes: " <> show baseDevice.exposes
+   windowCovering <|> defaultDevice
 
 decodeDevice :: Json -> Either JsonDecodeError Device
 decodeDevice deviceJson = do
@@ -228,69 +384,49 @@ decodeDevice deviceJson = do
 
   baseDevice <- decodeBaseDevice deviceJson exposes
 
-  --
-  -- Arguably this should be doing more comprehensive checks to
-  -- ensure that e.g. a device with a numeric brightness capability
-  -- also definitely has an on/off binary capability too. And it
-  -- probably will...some day. For now I'm relying on the idea that
-  -- these capabilities imply a hierarchy of functionality that
-  -- wouldn't mean much otherwise, and is implied by the device types
-  -- described in the Matter 1.2 protocol (which I think it's
-  -- reasonable to expect zigbee-compatibile devices to roughly
-  -- adhere to, both based on my experience looking at their feature
-  -- set along with the fact that the Zigbee Alliance is a major
-  -- contributer to Matter).
-  --
-  -- More practically speaking this also pushes a lot of the
-  -- responsibility for confirming functionality to the view layer,
-  -- and that's fine for now; the view layer has to manage a lot of
-  -- changing conditions regardless so it's not a bad tradeoff to
-  -- simplify this parsing code in return.
-  --
-  devices <- map sort $ for exposes $ \e ->
-    Right $ case e.featureType, e.type, e.name of
-      Just Light, Composite', "color_xy" -> ExtendedColorLight baseDevice
-      Just Light, Composite', "hue" -> ExtendedColorLight baseDevice
-      Just Light, Numeric', "color_temp" -> ColorTemperatureLight baseDevice
-      Just Light, Numeric', "brightness" -> DimmableLight baseDevice
-      Just Light, Binary', _ -> OnOffLight baseDevice
-      _, _, _ -> UnknownDevice baseDevice
+  let
+    defaultDevice = mkDefaultDevice baseDevice
 
-  -- see the comment above the definition for the Device data type to
-  -- understand what the sort above implies
-  pure $ head devices
+    lightDevice =
+      if hasCapabilities (\e -> e.featureType == Just Light) exposes then
+        decodeLightDevice baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a Light Device"
 
---
--- Matter device requirements. Each item following the previous inherits the previous item's requirements:
---
--- OnOffLight
--- - on/off switching
---
--- DimmableLight
--- - light level control
---
--- ColorTemperatureLight
--- - color temperature level control
---
--- ExtendedColorLight
--- - color control w/hue&saturation, enhanced hue (?), XY, color looping (?)
---
--- WindowCovering
--- - up/down for covering?
+    --
+    -- This one has no specific featureType so I have to do it this
+    -- ass-backwards way where I delineate all the specific sensor
+    -- type predicates and then do it again inside of
+    -- decodeSensorDevice, but this feels cleaner to me even if it's
+    -- less efficient. If it seems to cause performance issues I'll
+    -- do it the ugly...er, even uglier way ¯\_(ツ)_/¯
+    --
+    sensorDevice =
+      if flip hasCapabilities exposes $ \e ->
+           (e.name == "contact" && e.type == Binary') -- ContactSensor
+        || (e.name == "occupancy" && e.type == Binary') -- OccupancySensor
+      then
+        decodeSensorDevice baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a Sensor Device"
 
---
--- what about...
---
--- ## sensors
---
--- - humidity/temperature
--- - humidity/temp/air
--- - motion sensors
--- - door opening sensor
---
--- ## controls
---
--- - lighting on/off dimmer
--- - multi-control remote
---
+    closureDevice =
+      if hasCapabilities (\e -> e.featureType == Just Cover) exposes then
+        decodeClosureDevice baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a Closure Device"
 
+    returning =
+      lightDevice
+      <|> sensorDevice
+      <|> closureDevice
+      <|> defaultDevice
+
+  deviceType' <- deviceType <$> returning
+
+  when (deviceType' == "UnknownDevice") $
+    traceM $ baseDevice.name <> " - UnknownDevice, exposes " <> show baseDevice.exposes
+
+  traceM $ baseDevice.name <> " - final device type: " <> deviceType'
+
+  returning

--- a/ui/src/AutomationService/DeviceView.purs
+++ b/ui/src/AutomationService/DeviceView.purs
@@ -232,10 +232,17 @@ view { devices, deviceStates } dispatch =
             OnOffLight deviceDetails ->
               genericOnOffWithDetails mDeviceState deviceDetails []
 
+            ContactSensor deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
+            OccupancySensor deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
             WindowCovering deviceDetails ->
               genericWithDetails mDeviceState deviceDetails [] []
 
             UnknownDevice deviceDetails ->
+              H.div "border border-danger" $
               genericWithDetails mDeviceState deviceDetails [] []
 
     genericOnOffWithDetails

--- a/ui/src/AutomationService/DeviceView.purs
+++ b/ui/src/AutomationService/DeviceView.purs
@@ -38,6 +38,7 @@ import Data.Traversable (for_)
 import Effect.Class (liftEffect)
 import Effect.Ref (Ref)
 import Elmish (Transition, Dispatch, ReactElement, forkVoid, (<|), (<?|))
+import Elmish.HTML (_data)
 import Elmish.HTML.Events as E
 import Elmish.HTML.Styled as H
 import Foreign.Object as O
@@ -169,7 +170,8 @@ update ws s = case _ of
 
 view :: State -> Dispatch Message -> ReactElement
 view { devices, deviceStates } dispatch =
-  H.div "all-devices" -- "container mx-auto mt-5 d-flex flex-column justify-content-between"
+  H.div_ "all-devices" -- "container mx-auto mt-5 d-flex flex-column justify-content-between"
+  { _data: _data { "test-id": "all-devices" } }
   [ H.div "device-count" $ H.text $ (show $ L.length $ M.values devices) <> " Devices"
   , H.fragment $
     (\d -> deviceSummary (getDeviceState deviceStates d) d)
@@ -203,7 +205,7 @@ view { devices, deviceStates } dispatch =
 
     deviceSummary :: Maybe DeviceState -> Device -> ReactElement
     deviceSummary mDeviceState device =
-      H.div "col" $
+      H.div "col device" $
       H.div "card mt-2" $
         H.div "card-body text-bg-light p-3" $
           case device of
@@ -232,10 +234,22 @@ view { devices, deviceStates } dispatch =
             OnOffLight deviceDetails ->
               genericOnOffWithDetails mDeviceState deviceDetails []
 
+            GenericSwitch deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
             ContactSensor deviceDetails ->
               genericWithDetails mDeviceState deviceDetails [] []
 
             OccupancySensor deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
+            TemperatureSensor deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
+            HumiditySensor deviceDetails ->
+              genericWithDetails mDeviceState deviceDetails [] []
+
+            AirQualitySensor deviceDetails ->
               genericWithDetails mDeviceState deviceDetails [] []
 
             WindowCovering deviceDetails ->
@@ -286,7 +300,7 @@ view { devices, deviceStates } dispatch =
       Bootstrap.accordion {} $
         Bootstrap.accordionItem { eventKey: 0 }
         [
-          H.div_ "card-header d-flex flex-row justify-content-between"
+          H.div_ "card-header d-flex flex-row justify-content-between device-header"
           { style: H.css { minWidth: "11.5em" } } $
           [ deviceTitle deviceDetails ] <> headerComponents
         , Bootstrap.accordionHeader {} "detailed settings"

--- a/ui/src/AutomationService/Group.purs
+++ b/ui/src/AutomationService/Group.purs
@@ -6,17 +6,13 @@ module AutomationService.Group
   )
 where
 
-import AutomationService.Device (DeviceId)
-import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, encodeJson, toArray)
+import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, toArray)
 import Data.Argonaut.Decode.Combinators ((.:))
 import Data.Array (filter)
 import Data.Either (Either(..), isRight)
-import Data.Foldable (foldM)
-import Data.Map as M
-import Data.Map (Map)
 import Data.Maybe (Maybe(..))
-import Data.Traversable (sequence, traverse)
-import Prelude (($), (<$>), (=<<), (<#>), bind, map, pure)
+import Data.Traversable (sequence)
+import Prelude (($), (<$>), (=<<), bind, pure)
 
 type GroupScene = { id :: Int, name :: String }
 type GroupDevice = { id :: String, endpoint :: Int }

--- a/ui/src/AutomationService/MQTT.purs
+++ b/ui/src/AutomationService/MQTT.purs
@@ -12,7 +12,7 @@ where
 
 import Data.Argonaut (class EncodeJson, encodeJson, stringify)
 import Data.Int (floor)
-import Prelude (($), (<<<), (<>), (*))
+import Prelude (($), (<<<), (<>))
 
 -- helpers for generating MQTT messages to send to devices
 

--- a/ui/src/AutomationService/React/Bootstrap.purs
+++ b/ui/src/AutomationService/React/Bootstrap.purs
@@ -26,10 +26,9 @@ import Data.Undefined.NoProblem (Opt)
 import Elmish.React (ReactElement, createElement)
 import Elmish.React.Import (ImportedReactComponent,
                             ImportedReactComponentConstructorWithContent)
-import Elmish.HTML.Events (EventHandler, SyntheticEvent, handleEffect, stopPropagation)
+import Elmish.HTML.Events (SyntheticEvent)
 import Elmish.HTML.Styled as H
-import Foreign.Object (Object)
-import Prelude (Unit, ($), (<<<), const, pure, unit)
+import Prelude (Unit, ($), pure, unit)
 
 -- Accordion
 
@@ -69,7 +68,7 @@ foreign import accordionButton_ :: ImportedReactComponent
 foreign import accordionCollapse_ :: ImportedReactComponent
 
 foreign import useAccordionButton_
-  :: forall a. Int -> EffectFn1 SyntheticEvent Unit -> EffectFn1 SyntheticEvent Unit
+  :: Int -> EffectFn1 SyntheticEvent Unit -> EffectFn1 SyntheticEvent Unit
 
 type IconClass = String
 

--- a/ui/src/AutomationService/React/ColorWheel.purs
+++ b/ui/src/AutomationService/React/ColorWheel.purs
@@ -6,7 +6,6 @@ where
 import Effect.Uncurried (EffectFn1)
 import Elmish.React (createElement')
 import Elmish.React.Import (ImportedReactComponentConstructor, ImportedReactComponent)
-import Foreign (Foreign)
 import Foreign.Object (Object)
 import Prelude (Unit)
 

--- a/ui/test/src/Test/AutomationService/Elmish/Bootstrap.purs
+++ b/ui/test/src/Test/AutomationService/Elmish/Bootstrap.purs
@@ -19,7 +19,7 @@ import Prelude
 
 import Control.Monad.Reader (ReaderT, runReaderT)
 import Data.Traversable (traverse_)
-import Effect (Effect)
+-- import Effect (Effect)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Elmish (ComponentDef, ReactElement, construct)

--- a/ui/test/src/Test/AutomationService/WebSocketStub.purs
+++ b/ui/test/src/Test/AutomationService/WebSocketStub.purs
@@ -1,9 +1,6 @@
 module Test.AutomationService.WebSocketStub where
 
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
-import Prelude (Unit)
-import Web.Event.Event (Event)
 import Web.Event.EventTarget (EventTarget)
 
 webSocketStub :: Effect EventTarget

--- a/ui/test/src/Test/Fixtures.purs
+++ b/ui/test/src/Test/Fixtures.purs
@@ -402,3 +402,1423 @@ signeFixture = """
     "type": "Router"
   }
 """
+
+humiditySensorFixture :: String
+humiditySensorFixture = """
+{
+    "date_code": "2022-01-27 08:40",
+    "definition": {
+      "description": "Temperature & humidity sensor",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Indicates if the battery of this device is almost empty",
+          "label": "Battery low",
+          "name": "battery_low",
+          "property": "battery_low",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Measured temperature value",
+          "label": "Temperature",
+          "name": "temperature",
+          "property": "temperature",
+          "type": "numeric",
+          "unit": "Â°C"
+        },
+        {
+          "access": 1,
+          "description": "Measured relative humidity",
+          "label": "Humidity",
+          "name": "humidity",
+          "property": "humidity",
+          "type": "numeric",
+          "unit": "%"
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "HMSZB-110",
+      "options": [
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for temperature, takes into effect on next report of device.",
+          "label": "Temperature precision",
+          "name": "temperature_precision",
+          "property": "temperature_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the temperature value (absolute offset), takes into effect on next report of device.",
+          "label": "Temperature calibration",
+          "name": "temperature_calibration",
+          "property": "temperature_calibration",
+          "type": "numeric"
+        },
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for humidity, takes into effect on next report of device.",
+          "label": "Humidity precision",
+          "name": "humidity_precision",
+          "property": "humidity_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the humidity value (absolute offset), takes into effect on next report of device.",
+          "label": "Humidity calibration",
+          "name": "humidity_calibration",
+          "property": "humidity_calibration",
+          "type": "numeric"
+        }
+      ],
+      "supports_ota": false,
+      "vendor": "Develco"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genIdentify",
+            "genScenes",
+            "genOnOff"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "38": {
+        "bindings": [
+          {
+            "cluster": "genPollCtrl",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "msTemperatureMeasurement",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "msRelativeHumidity",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genPowerCfg",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "genPollCtrl",
+            "msTemperatureMeasurement",
+            "msRelativeHumidity"
+          ],
+          "output": [
+            "genIdentify",
+            "genTime",
+            "genOta"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "measuredValue",
+            "cluster": "msTemperatureMeasurement",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 10
+          },
+          {
+            "attribute": "measuredValue",
+            "cluster": "msRelativeHumidity",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 300
+          },
+          {
+            "attribute": "batteryVoltage",
+            "cluster": "genPowerCfg",
+            "maximum_report_interval": 43200,
+            "minimum_report_interval": 3600,
+            "reportable_change": 100
+          }
+        ],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Grow room temperature and humidity",
+    "ieee_address": "0x0015bc0035001e14",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "frient A/S",
+    "model_id": "HMSZB-110",
+    "network_address": 7639,
+    "power_source": "Battery",
+    "software_build_id": "3.4.6",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+motionSensorFixture :: String
+motionSensorFixture = """
+{
+    "date_code": "20220329 07:28",
+    "definition": {
+      "description": "Motion sensor",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Indicates whether the device detected occupancy",
+          "label": "Occupancy",
+          "name": "occupancy",
+          "property": "occupancy",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 7,
+          "label": "Occupancy timeout",
+          "name": "occupancy_timeout",
+          "property": "occupancy_timeout",
+          "type": "numeric",
+          "unit": "second",
+          "value_max": 65535,
+          "value_min": 20
+        },
+        {
+          "access": 1,
+          "description": "Measured temperature value",
+          "label": "Temperature",
+          "name": "temperature",
+          "property": "temperature",
+          "type": "numeric",
+          "unit": "Â°C"
+        },
+        {
+          "access": 1,
+          "description": "Measured illuminance in lux",
+          "label": "Illuminance (lux)",
+          "name": "illuminance_lux",
+          "property": "illuminance_lux",
+          "type": "numeric",
+          "unit": "lx"
+        },
+        {
+          "access": 1,
+          "description": "Indicates whether the device is tampered",
+          "label": "Tamper",
+          "name": "tamper",
+          "property": "tamper",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Indicates if the battery of this device is almost empty",
+          "label": "Battery low",
+          "name": "battery_low",
+          "property": "battery_low",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 7,
+          "description": "Control LED indicator usage.",
+          "label": "Led control",
+          "name": "led_control",
+          "property": "led_control",
+          "type": "enum",
+          "values": [
+            "off",
+            "fault_only",
+            "motion_only",
+            "both"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "MOSZB-140",
+      "options": [
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for temperature, takes into effect on next report of device.",
+          "label": "Temperature precision",
+          "name": "temperature_precision",
+          "property": "temperature_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the temperature value (absolute offset), takes into effect on next report of device.",
+          "label": "Temperature calibration",
+          "name": "temperature_calibration",
+          "property": "temperature_calibration",
+          "type": "numeric"
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the illuminance value (percentual offset), takes into effect on next report of device.",
+          "label": "Illuminance calibration",
+          "name": "illuminance_calibration",
+          "property": "illuminance_calibration",
+          "type": "numeric"
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the illuminance_lux value (percentual offset), takes into effect on next report of device.",
+          "label": "Illuminance lux calibration",
+          "name": "illuminance_lux_calibration",
+          "property": "illuminance_lux_calibration",
+          "type": "numeric"
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Develco"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genIdentify",
+            "genScenes",
+            "genOnOff"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "34": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msOccupancySensing"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "35": {
+        "bindings": [
+          {
+            "cluster": "genPollCtrl",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genPowerCfg",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "genBinaryInput",
+            "genPollCtrl",
+            "ssIasZone"
+          ],
+          "output": [
+            "genIdentify",
+            "genTime",
+            "genOta"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "batteryVoltage",
+            "cluster": "genPowerCfg",
+            "maximum_report_interval": 43200,
+            "minimum_report_interval": 3600,
+            "reportable_change": 100
+          }
+        ],
+        "scenes": []
+      },
+      "38": {
+        "bindings": [
+          {
+            "cluster": "msTemperatureMeasurement",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msTemperatureMeasurement"
+          ],
+          "output": []
+        },
+        "configured_reportings": [
+          {
+            "attribute": "measuredValue",
+            "cluster": "msTemperatureMeasurement",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 100
+          }
+        ],
+        "scenes": []
+      },
+      "39": {
+        "bindings": [
+          {
+            "cluster": "msIlluminanceMeasurement",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msIlluminanceMeasurement"
+          ],
+          "output": []
+        },
+        "configured_reportings": [
+          {
+            "attribute": "measuredValue",
+            "cluster": "msIlluminanceMeasurement",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 500
+          }
+        ],
+        "scenes": []
+      },
+      "40": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msOccupancySensing"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "41": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msOccupancySensing"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Basement stair top motion sensor",
+    "ieee_address": "0x0015bc001a0270a6",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "frient A/S",
+    "model_id": "MOSZB-140",
+    "network_address": 56495,
+    "power_source": "Battery",
+    "software_build_id": "4.0.3",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+controlsDeviceFixture :: String
+controlsDeviceFixture = """
+{
+    "date_code": "NULL",
+    "definition": {
+      "description": "4 zone remote and dimmer",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Triggered action (e.g. a button click)",
+          "label": "Action",
+          "name": "action",
+          "property": "action",
+          "type": "enum",
+          "values": [
+            "brightness_move_up",
+            "brightness_move_down",
+            "brightness_stop",
+            "on",
+            "off",
+            "recall_*"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "SR-ZG9001K12-DIM-Z4",
+      "options": [
+        {
+          "access": 2,
+          "description": "Simulate a brightness value. If this device provides a brightness_move_up or brightness_move_down action it is possible to specify the update interval and delta. The action_brightness_delta indicates the delta for each interval. ",
+          "features": [
+            {
+              "access": 2,
+              "description": "Delta per interval, 20 by default",
+              "label": "Delta",
+              "name": "delta",
+              "property": "delta",
+              "type": "numeric",
+              "value_min": 0
+            },
+            {
+              "access": 2,
+              "description": "Interval duration",
+              "label": "Interval",
+              "name": "interval",
+              "property": "interval",
+              "type": "numeric",
+              "unit": "ms",
+              "value_min": 0
+            }
+          ],
+          "label": "Simulated brightness",
+          "name": "simulated_brightness",
+          "property": "simulated_brightness",
+          "type": "composite"
+        },
+        {
+          "access": 2,
+          "description": "Set to false to disable the legacy integration (highly recommended), will change structure of the published payload (default true).",
+          "label": "Legacy",
+          "name": "legacy",
+          "property": "legacy",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        }
+      ],
+      "supports_ota": false,
+      "vendor": "Sunricher"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [
+          {
+            "cluster": "genOnOff",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genScenes",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "haDiagnostic",
+            "touchlink"
+          ],
+          "output": [
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "genOta",
+            "lightingColorCtrl",
+            "touchlink"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "2": {
+        "bindings": [
+          {
+            "cluster": "genOnOff",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "haDiagnostic",
+            "touchlink"
+          ],
+          "output": [
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "genOta",
+            "lightingColorCtrl",
+            "touchlink"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "3": {
+        "bindings": [
+          {
+            "cluster": "genOnOff",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "haDiagnostic",
+            "touchlink"
+          ],
+          "output": [
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "genOta",
+            "lightingColorCtrl",
+            "touchlink"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "4": {
+        "bindings": [
+          {
+            "cluster": "genOnOff",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "haDiagnostic",
+            "touchlink"
+          ],
+          "output": [
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "genOta",
+            "lightingColorCtrl",
+            "touchlink"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Vesternet Zigbee Remote Control - Twelve Button",
+    "ieee_address": "0xb4e3f9fffeec5e6a",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "Sunricher",
+    "model_id": "ZGRC-KEY-013",
+    "network_address": 17719,
+    "power_source": "Battery",
+    "software_build_id": "2.7.6_r25",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+contactSensorFixture :: String
+contactSensorFixture = """
+{
+    "date_code": "2020-09-08 14:34",
+    "definition": {
+      "description": "Window sensor",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Indicates if the contact is closed (= true) or open (= false)",
+          "label": "Contact",
+          "name": "contact",
+          "property": "contact",
+          "type": "binary",
+          "value_off": true,
+          "value_on": false
+        },
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Indicates if the battery of this device is almost empty",
+          "label": "Battery low",
+          "name": "battery_low",
+          "property": "battery_low",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Indicates whether the device is tampered",
+          "label": "Tamper",
+          "name": "tamper",
+          "property": "tamper",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Measured temperature value",
+          "label": "Temperature",
+          "name": "temperature",
+          "property": "temperature",
+          "type": "numeric",
+          "unit": "Â°C"
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "WISZB-120",
+      "options": [
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for temperature, takes into effect on next report of device.",
+          "label": "Temperature precision",
+          "name": "temperature_precision",
+          "property": "temperature_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the temperature value (absolute offset), takes into effect on next report of device.",
+          "label": "Temperature calibration",
+          "name": "temperature_calibration",
+          "property": "temperature_calibration",
+          "type": "numeric"
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Develco"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genIdentify",
+            "genScenes",
+            "genOnOff"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "35": {
+        "bindings": [
+          {
+            "cluster": "genPollCtrl",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genPowerCfg",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "genBinaryInput",
+            "genPollCtrl",
+            "ssIasZone"
+          ],
+          "output": [
+            "genTime",
+            "genOta"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "batteryVoltage",
+            "cluster": "genPowerCfg",
+            "maximum_report_interval": 62000,
+            "minimum_report_interval": 3600,
+            "reportable_change": 0
+          }
+        ],
+        "scenes": []
+      },
+      "38": {
+        "bindings": [
+          {
+            "cluster": "msTemperatureMeasurement",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "msTemperatureMeasurement"
+          ],
+          "output": [
+            "genIdentify"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "measuredValue",
+            "cluster": "msTemperatureMeasurement",
+            "maximum_report_interval": 3600,
+            "minimum_report_interval": 10,
+            "reportable_change": 100
+          }
+        ],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Front door entry sensor",
+    "ieee_address": "0x0015bc001e00f658",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "frient A/S",
+    "model_id": "WISZB-120",
+    "network_address": 21753,
+    "power_source": "Battery",
+    "software_build_id": "3.4.19",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+airQualitySensorFixture :: String
+airQualitySensorFixture = """
+{
+    "date_code": "20210824 22:26",
+    "definition": {
+      "description": "Air quality sensor",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Measured VOC value",
+          "label": "VOC",
+          "name": "voc",
+          "property": "voc",
+          "type": "numeric",
+          "unit": "Âµg/mÂ³"
+        },
+        {
+          "access": 1,
+          "description": "Measured temperature value",
+          "label": "Temperature",
+          "name": "temperature",
+          "property": "temperature",
+          "type": "numeric",
+          "unit": "Â°C"
+        },
+        {
+          "access": 1,
+          "description": "Measured relative humidity",
+          "label": "Humidity",
+          "name": "humidity",
+          "property": "humidity",
+          "type": "numeric",
+          "unit": "%"
+        },
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Indicates if the battery of this device is almost empty",
+          "label": "Battery low",
+          "name": "battery_low",
+          "property": "battery_low",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 1,
+          "description": "Measured air quality",
+          "label": "Air quality",
+          "name": "air_quality",
+          "property": "air_quality",
+          "type": "enum",
+          "values": [
+            "excellent",
+            "good",
+            "moderate",
+            "poor",
+            "unhealthy",
+            "out_of_range",
+            "unknown"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "AQSZB-110",
+      "options": [
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for voc, takes into effect on next report of device.",
+          "label": "Voc precision",
+          "name": "voc_precision",
+          "property": "voc_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the voc value (absolute offset), takes into effect on next report of device.",
+          "label": "Voc calibration",
+          "name": "voc_calibration",
+          "property": "voc_calibration",
+          "type": "numeric"
+        },
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for temperature, takes into effect on next report of device.",
+          "label": "Temperature precision",
+          "name": "temperature_precision",
+          "property": "temperature_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the temperature value (absolute offset), takes into effect on next report of device.",
+          "label": "Temperature calibration",
+          "name": "temperature_calibration",
+          "property": "temperature_calibration",
+          "type": "numeric"
+        },
+        {
+          "access": 2,
+          "description": "Number of digits after decimal point for humidity, takes into effect on next report of device.",
+          "label": "Humidity precision",
+          "name": "humidity_precision",
+          "property": "humidity_precision",
+          "type": "numeric",
+          "value_max": 3,
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "Calibrates the humidity value (absolute offset), takes into effect on next report of device.",
+          "label": "Humidity calibration",
+          "name": "humidity_calibration",
+          "property": "humidity_calibration",
+          "type": "numeric"
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Develco"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genIdentify",
+            "genScenes",
+            "genOnOff"
+          ],
+          "output": []
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "38": {
+        "bindings": [
+          {
+            "cluster": "genPollCtrl",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "develcoSpecificAirQuality",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "msTemperatureMeasurement",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "msRelativeHumidity",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genPowerCfg",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "genPollCtrl",
+            "msTemperatureMeasurement",
+            "msRelativeHumidity",
+            "1070",
+            "develcoSpecificAirQuality"
+          ],
+          "output": [
+            "genIdentify",
+            "genTime",
+            "genOta"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "measuredValue",
+            "cluster": "develcoSpecificAirQuality",
+            "maximum_report_interval": 3600,
+            "minimum_report_interval": 60,
+            "reportable_change": 10
+          },
+          {
+            "attribute": "measuredValue",
+            "cluster": "msTemperatureMeasurement",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 10
+          },
+          {
+            "attribute": "measuredValue",
+            "cluster": "msRelativeHumidity",
+            "maximum_report_interval": 600,
+            "minimum_report_interval": 60,
+            "reportable_change": 300
+          },
+          {
+            "attribute": "batteryVoltage",
+            "cluster": "genPowerCfg",
+            "maximum_report_interval": 43200,
+            "minimum_report_interval": 3600,
+            "reportable_change": 100
+          }
+        ],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Basement gym air quality sensor",
+    "ieee_address": "0x0015bc0036000f69",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "frient A/S",
+    "model_id": "AQSZB-110",
+    "network_address": 6480,
+    "power_source": "Battery",
+    "software_build_id": "4.0.1",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+windowCoveringFixture :: String
+windowCoveringFixture = """
+{
+    "date_code": "20201028",
+    "definition": {
+      "description": "TREDANSEN cellular blind",
+      "exposes": [
+        {
+          "features": [
+            {
+              "access": 3,
+              "label": "State",
+              "name": "state",
+              "property": "state",
+              "type": "enum",
+              "values": [
+                "OPEN",
+                "CLOSE",
+                "STOP"
+              ]
+            },
+            {
+              "access": 7,
+              "description": "Position of this cover",
+              "label": "Position",
+              "name": "position",
+              "property": "position",
+              "type": "numeric",
+
+
+              "unit": "%",
+              "value_max": 100,
+              "value_min": 0
+            }
+          ],
+          "type": "cover"
+        },
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported.",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "E2103",
+      "options": [
+        {
+          "access": 2,
+          "description": "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false).",
+          "label": "Invert cover",
+          "name": "invert_cover",
+          "property": "invert_cover",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "IKEA"
+    },
+    "disabled": false,
+    "endpoints": {
+      "1": {
+        "bindings": [
+          {
+            "cluster": "genPollCtrl",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "genPowerCfg",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          },
+          {
+            "cluster": "closuresWindowCovering",
+            "target": {
+              "endpoint": 1,
+              "ieee_address": "0x00212effff07fc2e",
+              "type": "endpoint"
+            }
+          }
+        ],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genPowerCfg",
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genPollCtrl",
+            "closuresWindowCovering",
+            "touchlink",
+            "64636"
+          ],
+          "output": [
+            "genOta",
+            "touchlink"
+          ]
+        },
+        "configured_reportings": [
+          {
+            "attribute": "batteryPercentageRemaining",
+            "cluster": "genPowerCfg",
+            "maximum_report_interval": 62000,
+            "minimum_report_interval": 3600,
+            "reportable_change": 0
+          },
+          {
+            "attribute": "currentPositionLiftPercentage",
+            "cluster": "closuresWindowCovering",
+            "maximum_report_interval": 62000,
+            "minimum_report_interval": 1,
+            "reportable_change": 1
+          }
+        ],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Master blinds - closet side",
+    "ieee_address": "0x84b4dbfffec40797",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "IKEA of Sweden",
+    "model_id": "TREDANSEN block-out cellul blind",
+    "network_address": 65519,
+    "power_source": "Battery",
+    "software_build_id": "24.4.11",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""
+
+unknownDeviceFixture :: String
+unknownDeviceFixture = """
+{
+    "date_code": "20210824 22:26",
+    "definition": {
+      "description": "it's a WAT",
+      "exposes": [
+        {
+          "access": 1,
+          "description": "Remaining battery in %, can take up to 24 hours before reported. The only thing this does is suck power",
+          "label": "Battery",
+          "name": "battery",
+          "property": "battery",
+          "type": "numeric",
+          "unit": "%",
+          "value_max": 100,
+          "value_min": 0
+        }
+      ]
+    },
+    "friendly_name": "WAT is this",
+    "ieee_address": "0x84b4dbfffec40797",
+    "manufacturer": "IKEA of Sweden",
+    "model_id": "FUNUNNKENHANSENNNEN",
+    "network_address": 65519,
+    "power_source": "Battery",
+    "supported": true,
+    "type": "EndDevice"
+  }
+"""

--- a/ui/test/src/Test/Main.purs
+++ b/ui/test/src/Test/Main.purs
@@ -16,28 +16,26 @@ import Effect.Ref as Ref
 import Elmish.Component (Command)
 -- see Test.AutomationService.Elmish.Bootstrap
 -- import Elmish.Test (find, prop, testComponent, text, (>>))
--- import Elmish.Test (find, prop, text, (>>), nearestEnclosingReactComponentName)
-import Elmish.Test (find, prop, (>>), nearestEnclosingReactComponentName)
+-- see note about text replacement below
+-- import Elmish.Test (find, prop, text, (>>))
+import Elmish.Test (find, prop, (>>))
 import Elmish.Test.DomProps as P
 import Elmish.Test.Events (change, click)
 import Foreign (unsafeFromForeign)
 import Main as Main
-import Prelude (Unit, bind, discard, pure, void, ($), (<<<), (>>>), (<$>), (<>), (>>=), (=<<))
+import Prelude (Unit, bind, discard, pure, void, ($), (<<<), (>>>), (<$>), (<>), (>>=))
 import Test.AutomationService.Elmish.Bootstrap (testComponent)
 import Test.AutomationService.Spec (Spec)
 import Test.AutomationService.WebSocketStub (webSocketStub)
 import Test.Fixtures as Fixtures
 import Test.Spec (before, describe, it)
 import Test.Spec.Assertions (shouldEqual)
+import Web.DOM.Element (Element, toNode)
+import Web.DOM.Node (textContent)
 import Web.Event.CustomEvent as CE
 import Web.Event.Event (EventType(..))
 import Web.Event.EventTarget (EventTarget, eventListener)
 import Web.Event.EventTarget as ET
-
-import Web.DOM.Element (Element, className, tagName, toNode, fromNode)
-import Web.DOM.Node (firstChild, nodeName, textContent)
-import Elmish.Test.State (class Testable, currentNode)
-import Debug (traceM)
 
 --
 -- For reasons that I don't understand, only when attempting to test
@@ -86,7 +84,7 @@ sendMessage ws msg = do
 spec :: Spec Unit
 spec = before setup $
   describe "Main app" $
-    it "Can navigate to different pages" $ \wsState@(TestWS { store, ws }) -> do
+    it "Can navigate to different pages" $ \wsState@(TestWS { store: _store, ws }) -> do
       let mqttMsg = "{\"start\": \"test\"}"
 
       newDsUpdateTimers <- liftEffect $ Ref.new M.empty
@@ -114,6 +112,9 @@ spec = before setup $
           find ("li" `withTestId` "nav-devices" <> " a") >> click
           find ("h2" `withTestId` "main-title") >>= text
             >>= shouldEqual "Devices"
+
+          find "div.all-devices div.device .card-body .card-header" >>= text
+            >>= shouldEqual "Basement Black Signe"
 
           -- Publish MQTT
           find ("li" `withTestId` "nav-publish-mqtt" <> " a") >> click


### PR DESCRIPTION
Re: #32 

- [x] all devices that I can personally (manually) test should be identified correctly
- [x] there should be a test or tests exercising device decoding for all types included in the above point
- [x] get rid of as many PS warnings as possible, there are a bunch that have been hanging around a while

I started extending the device-specific tests to the UI but it is really still an ugly hack and more importantly it would take a bunch more work to be able to differentiate devices in the UI in a way I wouldn't just be refactoring later on, so I left that alone for now. Todo: fix up the device UI, obvs 