### PR TITLE
Make Capabilities into specific types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: "Build and publish image to ghcr.io"
+name: "Build (feature branch) or build and publish image to ghcr.io (main branch)"
 
 on: push
 

--- a/ui/src/AutomationService/Device.purs
+++ b/ui/src/AutomationService/Device.purs
@@ -1,9 +1,10 @@
 module AutomationService.Device
-  ( Device(..)
+  ( Decoded(..)
+  , DecodedStatus(..)
+  , Device(..)
   , DeviceDetails
   , DeviceId
   , Devices
-  , DeviceType(..)
   , _category
   , _deviceDetails
   , _exposes
@@ -15,30 +16,32 @@ module AutomationService.Device
   , decodeDevices
   , details
   , deviceTopic
-  , deviceType
   , getTopic
+  , mkFailedParse
   , setDetails
   , setTopic
   )
 where
 
-import AutomationService.Exposes (Capability, CapType(..), Exposes, FeatureType(..), decodeExposes)
+import AutomationService.Exposes (Capability(..), CapabilityDetails, Exposes, FeatureType(..), capabilityDetails, decodeExposes)
 import Control.Alt ((<|>))
 import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, toArray)
 import Data.Argonaut.Decode.Combinators ((.:), (.:?))
-import Data.Array (filter, null)
+import Data.Array (filter, length, null)
 import Data.Array.NonEmpty (fromArray)
 import Data.Array.NonEmpty as NonEmpty
-import Data.Either (Either(..), isRight)
+import Data.Either (Either(..), isLeft, isRight)
+import Data.Foldable (foldr)
 import Data.Generic.Rep (class Generic)
 import Data.Lens (Lens, Lens', lens')
 import Data.Lens.Record (prop)
 import Data.Map (Map)
+import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.Show.Generic (genericShow)
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(..))
-import Prelude (class Eq, class Ord, class Show, bind, flip, not, pure, (<<<), ($), (<$>), (<>), (=<<), (==), (&&), (||))
+import Prelude (class Eq, class Ord, class Show, (<<<), (>>>), ($), (#), (<$>), (<>), (=<<), (==), (||), bind, flip, not, pure)
 import Type.Proxy (Proxy(..))
 
 type DeviceId = String
@@ -139,6 +142,7 @@ data Device
   | OnOffLight DeviceDetails
   | GenericSwitch DeviceDetails
   | ContactSensor DeviceDetails
+  | LightSensor DeviceDetails
   | OccupancySensor DeviceDetails
   | HumiditySensor DeviceDetails
   | TemperatureSensor DeviceDetails
@@ -163,6 +167,7 @@ details = case _ of
   OnOffLight d -> d
   GenericSwitch d -> d
   ContactSensor d -> d
+  LightSensor d -> d
   OccupancySensor d -> d
   HumiditySensor d -> d
   TemperatureSensor d -> d
@@ -178,6 +183,7 @@ setDetails d = case _ of
   OnOffLight _ -> OnOffLight d
   GenericSwitch _ -> GenericSwitch d
   ContactSensor _ -> ContactSensor d
+  LightSensor _ -> LightSensor d
   OccupancySensor _ -> OccupancySensor d
   HumiditySensor _ -> HumiditySensor d
   TemperatureSensor _ -> TemperatureSensor d
@@ -187,43 +193,6 @@ setDetails d = case _ of
 
 _deviceDetails :: Lens' Device DeviceDetails
 _deviceDetails = lens' $ \d -> Tuple (details d) (flip setDetails d)
-
--- an experiment, mostly for tests at this point
-data DeviceType
-  = ExtendedColorLight'
-  | ColorTemperatureLight'
-  | DimmableLight'
-  | OnOffLight'
-  | GenericSwitch'
-  | ContactSensor'
-  | OccupancySensor'
-  | HumiditySensor'
-  | TemperatureSensor'
-  | AirQualitySensor'
-  | WindowCovering'
-  | UnknownDevice'
-
-derive instance Eq DeviceType
-derive instance Generic DeviceType _
-derive instance Ord DeviceType
-
-instance Show DeviceType where
-  show = genericShow
-
-deviceType :: Device -> DeviceType
-deviceType = case _ of
-  ExtendedColorLight _ -> ExtendedColorLight'
-  ColorTemperatureLight _ -> ColorTemperatureLight'
-  DimmableLight _ -> DimmableLight'
-  OnOffLight _ -> OnOffLight'
-  GenericSwitch _ -> GenericSwitch'
-  ContactSensor _ -> ContactSensor'
-  OccupancySensor _ -> OccupancySensor'
-  HumiditySensor _ -> HumiditySensor'
-  TemperatureSensor _ -> TemperatureSensor'
-  AirQualitySensor _ -> AirQualitySensor'
-  WindowCovering _ -> WindowCovering'
-  UnknownDevice _ -> UnknownDevice'
 
 -- okay I guess these go in here too
 
@@ -238,16 +207,74 @@ getTopic name' = deviceTopic name' <> "/get"
 
 --
 
-decodeDevices :: Json -> Either JsonDecodeError (Array Device)
+data DecodedStatus
+  = DecodingSucceeded
+  | DecodingFailed
+  | NoDevicesDecoded
+  | BadJson
+
+derive instance Generic DecodedStatus _
+
+instance Show DecodedStatus where
+  show = genericShow
+
+data Decoded a
+  = Decoded a
+  { devices :: Devices
+  , errors :: Array (Either JsonDecodeError Device)
+  }
+
+derive instance Generic (Decoded a) _
+
+instance Show a => Show (Decoded a) where
+  show decoded = genericShow decoded
+
+mkFailedParse :: Either JsonDecodeError Json -> Decoded DecodedStatus
+mkFailedParse json
+  = Decoded BadJson
+  { devices: M.empty
+  , errors: [Left <<< UnexpectedValue =<< json] }
+
+decodeDevices :: Json -> Decoded DecodedStatus
 decodeDevices devicesJson = do
   case toArray devicesJson of
     Just ds ->
-      -- REPORT THESE FAILURES! Either isn't really enough for what I want here?
-      case (filter isRight $ decodeDevice <$> ds) of
-        [] -> Left (UnexpectedValue devicesJson)
-        ds' -> sequence ds'
+      let
+        decodedDevices = decodeDevice <$> ds
+      in
+       case sequence $ filter isRight decodedDevices of
+          Right devices ->
+            let
+              decodedDevicesMap =
+                foldr
+                  (\d devices' ->
+                    M.insert (_.id <<< details $ d) d devices'
+                  )
+                  M.empty
+                  devices
+            in
+             if M.isEmpty decodedDevicesMap then
+               Decoded NoDevicesDecoded
+               { devices: decodedDevicesMap
+               , errors: filter isLeft decodedDevices
+               }
+             else
+               Decoded DecodingSucceeded
+               { devices: decodedDevicesMap
+               , errors: filter isLeft decodedDevices
+               }
+
+          Left error ->
+            Decoded DecodingFailed
+            { devices: M.empty
+            , errors: [Left error]
+            }
+
     Nothing ->
-      Left (UnexpectedValue devicesJson)
+      Decoded DecodingFailed
+      { devices: M.empty
+      , errors: [Left (UnexpectedValue devicesJson)]
+      }
 
 decodeBaseDevice :: Json -> Exposes -> Either JsonDecodeError DeviceDetails
 decodeBaseDevice deviceJson exposes = do
@@ -259,50 +286,64 @@ decodeBaseDevice deviceJson exposes = do
   model <- obj .:? "model_id"
   pure $ { id: id', name: name', category, manufacturer, model, exposes }
 
-hasCapabilities :: Exposes -> (Capability -> Boolean) -> Boolean
-hasCapabilities exposes pred =
-    not <<< null <<< NonEmpty.filter pred $ exposes
+featureType :: Exposes -> FeatureType -> Boolean
+featureType exposes ft =
+  exposes #
+  NonEmpty.filter ((\ft' -> ft' == Just ft) <<< _.featureType <<< capabilityDetails)
+  >>> null
+  >>> not
+
+capabilities :: Exposes -> Array (CapabilityDetails -> Capability) -> Boolean
+capabilities exposes matchCapabilities =
+  length(matches) == length(matchCapabilities)
+
+  where
+    matches =
+      filter
+        (\capCons -> not <<< null <<< NonEmpty.filter (is capCons) $ exposes)
+        matchCapabilities
+
+    is :: (CapabilityDetails -> Capability) -> Capability -> Boolean
+    is cons v = v == (cons <<< capabilityDetails $ v)
 
 mkDefaultDevice :: DeviceDetails -> Either JsonDecodeError Device
 mkDefaultDevice = Right <<< UnknownDevice
+
 
 --
 -- Matter Device Library Specification R1.4
 -- Chapter 4. Lighting Device Types
 --
 decodeLightDevice :: DeviceDetails -> Either JsonDecodeError Device
-decodeLightDevice baseDevice =
+decodeLightDevice baseDevice@{ exposes } =
   let
     defaultDevice = mkDefaultDevice baseDevice
 
     extendedColorLight =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        (e.name == "color_xy" || e.name == "hue")
-        && e.type == Composite'
+      if    exposes `capabilities` [OnOff, Brightness, ColorHue]
+         || exposes `capabilities` [OnOff, Brightness, ColorXY]
+         || exposes `capabilities` [OnOff, Brightness, ColorHex]
       then
         Right <<< ExtendedColorLight $ baseDevice
       else
         Left <<< TypeMismatch $ "Not an ExtendedColorLight"
 
     colorTemperatureLight =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "color_temp" && e.type == Numeric'
+      if exposes `capabilities` [OnOff, Brightness, ColorTemperature]
       then
         Right <<< ColorTemperatureLight $ baseDevice
       else
         Left <<< TypeMismatch $ "Not a ColorTemperatureLight"
 
     dimmableLight =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "brightness" && e.type == Numeric'
+      if exposes `capabilities` [OnOff, Brightness]
       then
         Right <<< DimmableLight $ baseDevice
       else
-        Left <<< TypeMismatch $ "Not an DimmableLight"
+        Left <<< TypeMismatch $ "Not a DimmableLight"
 
     onOffLight =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.type == Binary'
+      if exposes `capabilities` [OnOff]
       then
         Right <<< OnOffLight $ baseDevice
       else
@@ -331,7 +372,7 @@ decodeLightDevice baseDevice =
 -- Chapter 6. Switches and Controls Device Types
 --
 decodeControlsDevice :: DeviceDetails -> Either JsonDecodeError Device
-decodeControlsDevice baseDevice =
+decodeControlsDevice baseDevice@{ exposes } =
   let
     defaultDevice = mkDefaultDevice baseDevice
 
@@ -346,8 +387,7 @@ decodeControlsDevice baseDevice =
     --
 
     genericSwitch =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "action" && e.type == Enum'
+      if exposes `capabilities` [Switch]
       then
         Right <<< GenericSwitch $ baseDevice
       else
@@ -362,7 +402,7 @@ decodeControlsDevice baseDevice =
 -- Chapter 7. Sensor Device Types
 --
 decodeSensorDevice :: DeviceDetails -> Either JsonDecodeError Device
-decodeSensorDevice baseDevice =
+decodeSensorDevice baseDevice@{ exposes } =
   let
     defaultDevice = mkDefaultDevice baseDevice
 
@@ -380,53 +420,52 @@ decodeSensorDevice baseDevice =
     --
 
     contactSensor =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "contact" && e.type == Binary'
+      if exposes `capabilities` [Contact]
       then
         Right <<< ContactSensor $ baseDevice
       else
         Left <<< TypeMismatch $ "Not a ContactSensor"
 
+    lightSensor =
+      if exposes `capabilities` [IlluminanceLux]
+      then
+        Right <<< LightSensor $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a LightSensor"
+
     occupancySensor =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "occupancy" && e.type == Binary'
+      if exposes `capabilities` [Occupancy]
       then
         Right <<< OccupancySensor $ baseDevice
       else
-        Left <<< TypeMismatch $ "Not a OccupancySensor"
-
-    humiditySensor =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "humidity" && e.type == Numeric'
-      then
-        Right <<< HumiditySensor $ baseDevice
-      else
-        Left <<< TypeMismatch $ "Not a HumiditySensor"
+        Left <<< TypeMismatch $ "Not an OccupancySensor"
 
     temperatureSensor =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "temperature" && e.type == Numeric'
+      if exposes `capabilities` [Temperature]
       then
         Right <<< TemperatureSensor $ baseDevice
       else
         Left <<< TypeMismatch $ "Not a TemperatureSensor"
 
+    humiditySensor =
+      if exposes `capabilities` [Humidity]
+      then
+        Right <<< HumiditySensor $ baseDevice
+      else
+        Left <<< TypeMismatch $ "Not a HumiditySensor"
+
     airQualitySensor =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        -- Not really sure which of these is "correct", so just
-        -- checking for them both in any case since they both fit the
-        -- definition:
-        (e.name == "air_quality" && e.type == Enum')
-        || (e.name == "voc" && e.type == Numeric')
+      if exposes `capabilities` [AirQuality]
       then
         Right <<< AirQualitySensor $ baseDevice
       else
-        Left <<< TypeMismatch $ "Not a AirQualitySensor"
+        Left <<< TypeMismatch $ "Not an AirQualitySensor"
 
   in
     contactSensor
+      <|> lightSensor
       <|> occupancySensor
-      -- This is one case where the ordering matters; most humidity
+      -- This is one case where the ordering matters: most humidity
       -- sensors are also temperature sensors, and air quality sensors
       -- include both as well. So if we choose the wrong one here we may
       -- miss out on being able to dispatch the most
@@ -444,7 +483,7 @@ decodeSensorDevice baseDevice =
 -- Chapter 8. Closure Device Types
 --
 decodeClosureDevice :: DeviceDetails -> Either JsonDecodeError Device
-decodeClosureDevice baseDevice =
+decodeClosureDevice baseDevice@{ exposes } =
   let
     defaultDevice = mkDefaultDevice baseDevice
 
@@ -457,8 +496,7 @@ decodeClosureDevice baseDevice =
     --
 
     windowCovering =
-      if hasCapabilities baseDevice.exposes $ \e ->
-        e.name == "position" && e.type == Numeric'
+      if exposes `capabilities` [Covering]
       then
         Right <<< WindowCovering $ baseDevice
       else
@@ -483,9 +521,9 @@ decodeDevice deviceJson = do
     Just definition -> do
       exposes <- definition .:? "exposes"
       case fromArray =<< exposes of
-        Just exposes' -> decodeExposes Nothing exposes'
-        _ -> Left (TypeMismatch $ "Empty exposes list")
-    Nothing -> Left (TypeMismatch $ "No definition")
+        Just exposes' -> decodeExposes exposes'
+        _ -> Left (TypeMismatch "Empty exposes list")
+    Nothing -> Left (UnexpectedValue deviceJson)
 
   baseDevice <- decodeBaseDevice deviceJson exposes
 
@@ -493,16 +531,15 @@ decodeDevice deviceJson = do
     defaultDevice = mkDefaultDevice baseDevice
 
     lightDevice =
-      if hasCapabilities exposes $ \e ->
-        e.featureType == Just Light
+      if exposes `featureType` Light
       then
         decodeLightDevice baseDevice
       else
         Left <<< TypeMismatch $ "Not a Light Device"
 
+    -- see comment for sensor values below
     controlsDevice =
-      if hasCapabilities exposes $ \e ->
-        e.name == "action" && e.type == Enum'
+      if exposes `capabilities` [Switch]
       then
         decodeControlsDevice baseDevice
       else
@@ -517,13 +554,12 @@ decodeDevice deviceJson = do
     -- do it the ugly...er, even uglier way ¯\_(ツ)_/¯
     --
     sensorDevice =
-      if hasCapabilities exposes $ \e ->
-           e.name == "contact" && e.type == Binary'      -- ContactSensor
-        || e.name == "occupancy" && e.type == Binary'    -- OccupancySensor
-        || e.name == "temperature" && e.type == Numeric' -- TemperatureSensor
-        || e.name == "humidity" && e.type == Numeric'    -- HumiditySensor
-        || e.name == "air_quality" && e.type == Enum'    -- AirQualitySensor
-        || e.name == "voc" && e.type == Numeric'         -- AirQualitySensor
+      if    exposes `capabilities` [Contact]
+         || exposes `capabilities` [IlluminanceLux]
+         || exposes `capabilities` [Occupancy]
+         || exposes `capabilities` [Temperature]
+         || exposes `capabilities` [Humidity]
+         || exposes `capabilities` [AirQuality]
       then
         decodeSensorDevice baseDevice
       else
@@ -536,8 +572,7 @@ decodeDevice deviceJson = do
     -- like lights do wrt featureType being consistent?
     --
     closureDevice =
-      if hasCapabilities exposes $ \e ->
-        e.featureType == Just Cover
+      if exposes `featureType` Cover
       then
         decodeClosureDevice baseDevice
       else

--- a/ui/src/AutomationService/DeviceMessage.purs
+++ b/ui/src/AutomationService/DeviceMessage.purs
@@ -5,14 +5,14 @@ where
 
 import Prelude (class Show)
 
-import AutomationService.Device (Device, DeviceId)
+import AutomationService.Device (Devices, DeviceId)
 import AutomationService.DeviceState (DeviceState)
 import AutomationService.Group (Group)
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
 
 data Message
-  = LoadDevices (Array Device)
+  = LoadDevices Devices
   | LoadDevicesFailed String
   | LoadDeviceState DeviceState
   | LoadDeviceStateFailed String

--- a/ui/src/AutomationService/Group.purs
+++ b/ui/src/AutomationService/Group.purs
@@ -6,16 +6,18 @@ module AutomationService.Group
   )
 where
 
+import AutomationService.Device (Device, Devices)
 import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, toArray)
 import Data.Argonaut.Decode.Combinators ((.:))
 import Data.Array (filter)
 import Data.Either (Either(..), isRight)
+import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.Traversable (sequence)
-import Prelude (($), (<$>), (=<<), bind, pure)
+import Prelude ((<<<), ($), (<$>), (=<<), (<>), bind, pure)
 
 type GroupScene = { id :: Int, name :: String }
-type GroupDevice = { id :: String, endpoint :: Int }
+type GroupDevice = { id :: String, endpoint :: Int, device :: Device }
 
 type Group =
   { name :: String
@@ -24,23 +26,23 @@ type Group =
   , scenes :: Array GroupScene
   }
 
-decodeGroups :: Json -> Either JsonDecodeError (Array Group)
-decodeGroups groupsJson = do
+decodeGroups :: Devices -> Json -> Either JsonDecodeError (Array Group)
+decodeGroups devices groupsJson = do
   case toArray groupsJson of
     Just gs -> 
       -- REPORT THESE FAILURES! Either isn't really enough for what I want here?
-      case (filter isRight $ decodeGroup <$> gs) of
+      case (filter isRight $ decodeGroup devices <$> gs) of
         [] -> Left (UnexpectedValue groupsJson)
         ds' -> sequence ds'
     Nothing ->
       Left (UnexpectedValue groupsJson)
 
-decodeGroup :: Json -> Either JsonDecodeError Group
-decodeGroup groupJson = do
+decodeGroup :: Devices -> Json -> Either JsonDecodeError Group
+decodeGroup devices groupJson = do
   obj <- decodeJson groupJson
   name <- obj .: "friendly_name"
   id <- obj .: "id"
-  members <- decodeGroupResource decodeMember =<< obj .: "members"
+  members <- decodeGroupResource (decodeMember devices) =<< obj .: "members"
   scenes <- decodeGroupResource decodeScene =<< obj .: "scenes"
   pure { name, id, members, scenes }
 
@@ -53,12 +55,16 @@ decodeGroup groupJson = do
       [] -> Right []
       grs' -> sequence grs'
 
-    decodeMember :: Json -> Either JsonDecodeError GroupDevice
-    decodeMember memberJson = do
+    decodeMember :: Devices -> Json -> Either JsonDecodeError GroupDevice
+    decodeMember devices' memberJson = do
       obj <- decodeJson memberJson
       endpoint <- obj .: "endpoint"
       id <- obj .: "ieee_address"
-      pure { id, endpoint }
+      case M.lookup id devices' of
+        Just device ->
+          pure { id, endpoint, device }
+        Nothing ->
+          Left <<< TypeMismatch $ "No device with id " <> id <> " exists"
 
     decodeScene :: Json -> Either JsonDecodeError GroupScene
     decodeScene sceneJson = do

--- a/ui/src/AutomationService/GroupView.purs
+++ b/ui/src/AutomationService/GroupView.purs
@@ -11,7 +11,7 @@ import Data.Array as Array
 -- import Data.Maybe (Maybe)
 import Elmish (Dispatch, ReactElement) -- , (<|), (<?|))
 import Elmish.HTML.Styled as H
-import Prelude (($), (<<<), (<>), (<#>), show)
+import Prelude (($), (<>), (<#>), show)
 
 view :: Devices.State -> Dispatch Devices.Message -> ReactElement
 view _state@{ groups } _dispatch =

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -120,8 +120,10 @@ update s = case _ of
                 liftEffect <<< warn $ "Decoding errors: " <> show errors
               msgSink' <<< Devices.LoadDevices $ devices'
 
+            -- We may also get this when we have mismatched JSON, so
+            -- keeping these at debug level as well:
             Decoded DecodingFailed { errors } -> do
-              liftEffect <<< warn $ "Decoding failed: " <> show errors
+              liftEffect <<< debug $ "Decoding failed: " <> show errors
               msgSink' <<< Devices.LoadDevicesFailed <<< show $ errors
 
             Decoded BadJson { errors } -> do

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -8,7 +8,7 @@ import AutomationService.DeviceView (DeviceStateUpdateTimers, State, initState, 
 import AutomationService.Group (decodeGroups) as Groups
 import AutomationService.GroupView (view) as Groups
 import AutomationService.Helpers (allElements, maybeHtml)
-import AutomationService.Logging (LogLevel(..), debug, info, warn)
+import AutomationService.Logging (LogLevel(..), debug, warn)
 import AutomationService.Logging as Logging
 import AutomationService.Message (Message(..), Page(..), pageName, pageNameClass)
 import AutomationService.Message as Page
@@ -121,11 +121,11 @@ update s = case _ of
               msgSink' <<< Devices.LoadDevices $ devices'
 
             Decoded DecodingFailed { errors } -> do
-              liftEffect <<< info $ "Decoding failed: " <> show errors
+              liftEffect <<< warn $ "Decoding failed: " <> show errors
               msgSink' <<< Devices.LoadDevicesFailed <<< show $ errors
 
             Decoded BadJson { errors } -> do
-              liftEffect <<< info $ "Bad JSON: " <> show errors
+              liftEffect <<< debug $ "Bad JSON: " <> show errors
 
           msgSink' $ either
             (Devices.LoadGroupsFailed <<< show)

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -1,20 +1,23 @@
 module Main where
 
-import AutomationService.Device (decodeDevices) as Devices
+import AutomationService.Device (Decoded(..), DecodedStatus(..))
+import AutomationService.Device (decodeDevices, mkFailedParse) as Devices
 import AutomationService.DeviceMessage (Message(..)) as Devices
 import AutomationService.DeviceState as DeviceState
 import AutomationService.DeviceView (DeviceStateUpdateTimers, State, initState, update, view) as Devices
 import AutomationService.Group (decodeGroups) as Groups
 import AutomationService.GroupView (view) as Groups
 import AutomationService.Helpers (allElements, maybeHtml)
-import AutomationService.Logging (LogLevel(..), debug)
+import AutomationService.Logging (LogLevel(..), debug, info, warn)
 import AutomationService.Logging as Logging
 import AutomationService.Message (Message(..), Page(..), pageName, pageNameClass)
 import AutomationService.Message as Page
 import AutomationService.WebSocket (class WebSocket, addWSEventListener, connectToWS, sendString)
+import Control.Monad (when)
 import Data.Argonaut (parseJson)
+import Data.Array (null)
 import Data.Bifunctor (bimap)
-import Data.Either (either)
+import Data.Either (either, fromRight)
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.Traversable (for_)
@@ -29,7 +32,7 @@ import Elmish.Component (Command)
 import Elmish.HTML (_data)
 import Elmish.HTML.Events as E
 import Elmish.HTML.Styled as H
-import Prelude (Unit, ($), (#), (<>), (<<<), (<#>), (=<<), bind, discard, pure, show)
+import Prelude (Unit, ($), (#), (<>), (<<<), (<$>), (<#>), (=<<), bind, discard, not, pure, show)
 
 type State ws =
   { currentPage :: Page
@@ -77,13 +80,18 @@ update s = case _ of
         messageHandler = \msgStr -> do
           let
             jsonBlob = parseJson msgStr
-            devices = Devices.decodeDevices =<< jsonBlob
+            devices = fromRight (Devices.mkFailedParse jsonBlob) $
+                        Devices.decodeDevices <$> jsonBlob
             deviceState = DeviceState.decodeDeviceState =<< jsonBlob
-            groups = Groups.decodeGroups =<< jsonBlob
+            groups = case devices of
+              Decoded DecodingSucceeded devices' ->
+                Groups.decodeGroups devices'.devices =<< jsonBlob
+              _ ->
+                Groups.decodeGroups s.devices.devices =<< jsonBlob
 
           liftEffect $ do
             debug $ show devices
-            debug $ msgStr
+            debug msgStr
 
           -- okay, one thing that is needed is a ux for when state hasn't
           -- loaded yet
@@ -93,10 +101,31 @@ update s = case _ of
             Devices.LoadDeviceState
             deviceState
 
-          msgSink' $ either
-            (Devices.LoadDevicesFailed <<< show)
-            Devices.LoadDevices
-            devices
+          -- make appropriate noise about device decoding failures
+          case devices of
+            Decoded NoDevicesDecoded { errors } -> do
+              -- If we don't have any devices then it's likely any
+              -- errors are going to be obviously because we were
+              -- trying to decode the wrong type of JSON (i.e.
+              -- DeviceState or Groups JSON), so we keep the log
+              -- level at debug to avoid a ton of noise:
+              liftEffect <<< debug $ "Devices are empty, errors are " <> show errors
+
+            -- DecodingSucceeded implies we have at least one device
+            Decoded DecodingSucceeded { devices: devices', errors } -> do
+              -- log any decoding failures when we do have devices,
+              -- as we know these should be about devices that we
+              -- aren't decoding properly
+              when (not null errors) $
+                liftEffect <<< warn $ "Decoding errors: " <> show errors
+              msgSink' <<< Devices.LoadDevices $ devices'
+
+            Decoded DecodingFailed { errors } -> do
+              liftEffect <<< info $ "Decoding failed: " <> show errors
+              msgSink' <<< Devices.LoadDevicesFailed <<< show $ errors
+
+            Decoded BadJson { errors } -> do
+              liftEffect <<< info $ "Bad JSON: " <> show errors
 
           msgSink' $ either
             (Devices.LoadGroupsFailed <<< show)

--- a/ui/test/fixtures.json
+++ b/ui/test/fixtures.json
@@ -229,7 +229,7 @@
         "scenes": []
       }
     },
-    "friendly_name": "Grow room temperature and humidity",
+    "friendly_name": "Temperature and humidity",
     "ieee_address": "0x0015bc0035001e14",
     "interview_completed": true,
     "interviewing": false,
@@ -19111,4 +19111,232 @@
     "supported": true,
     "type": "Router"
   }
-]
+  // this is just me being lazy and dumping the groups JSON out
+  // without needing to split this into two files. Also I think valid
+  // JSON doesn't have comments? I forget
+  {"groups":
+   [
+     {
+       "friendly_name": "Basement Standing Lamp",
+       "id": 1,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c9d3dc7"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c48279d"
+	 }
+       ],
+       "scenes": [
+	 {
+           "id": 0,
+           "name": "Chrimbus"
+	 },
+	 {
+           "id": 1,
+           "name": "Chilly"
+	 }
+       ]
+     },
+     {
+       "friendly_name": "Living Room Lighting",
+       "id": 2,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x680ae2fffe4577ac"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c9941c5"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b2e53"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b38af"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010bfadf37"
+	 }
+       ],
+       "scenes": []
+     },
+     {
+       "friendly_name": "Gym Ceiling - All",
+       "id": 3,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d098"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e182"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d37096e"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d3711cb"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d1c9"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e7aa"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d8cd"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d7d7"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d1fa"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d100"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00dfdb"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00dd15"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d757"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d079"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d052"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d142"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e25a"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00c864"
+	 }
+       ],
+       "scenes": []
+     },
+     {
+       "friendly_name": "Basement Main - All Ceiling Lights",
+       "id": 4,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e7e5"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e80c"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e9d3"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00ea47"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d102"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d063"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00dd82"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d05e"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d161"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d724"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e263"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d7eb"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00d131"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e256"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010d00e189"
+	 }
+       ],
+       "scenes": []
+     },
+     {
+       "friendly_name": "Living Room Standing Lamp",
+       "id": 5,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c9941c5"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b2e53"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b38af"
+	 }
+       ],
+       "scenes": []
+     },
+     {
+       "friendly_name": "default_bind_group",
+       "id": 901,
+       "members": [],
+       "scenes": []
+     }
+   ]
+  ]

--- a/ui/test/src/Test/AutomationService/Exposes.purs
+++ b/ui/test/src/Test/AutomationService/Exposes.purs
@@ -74,5 +74,16 @@ spec =
 
       subProps `shouldEqual` Just subPropsFixture
 
-      -- signe `shouldHaveCapabilities` [OnOff, Brightness, ColorHue]
-      signe `shouldHaveCapabilities` [OnOff, Brightness, ColorHue, Occupancy]
+      signe `shouldHaveCapabilities`
+        [ Brightness
+        , ColorGradient
+        , ColorHue
+        , ColorTempStartup
+        , ColorTemperature
+        , ColorXY
+        , Effect
+        , GradientScene
+        , LinkQuality
+        , OnOff
+        , PowerOnBehavior
+        ]

--- a/ui/test/src/Test/AutomationService/Exposes.purs
+++ b/ui/test/src/Test/AutomationService/Exposes.purs
@@ -1,21 +1,21 @@
 module Test.AutomationService.Exposes where
 
-import AutomationService.Exposes (CapType(..), FeatureType(..), SubProps(..),
-                                  _access, _description, _featureType, _label, _name,
-                                  _property, _subProps, _type, canGet, canSet,
-                                  capabilityDetails, isPublished, decodeExposes)
+import AutomationService.Exposes (Capability(..), CapType(..), FeatureType(..), SubProps(..), _access,
+                                  _description, _featureType, _label, _name, _property, _subProps, _type,
+                                  canGet, canSet, capabilityDetails, decodeExposes, -- featureType,
+                                  isPublished)
 import Data.Argonaut.Decode ((.:), (.:?), fromJsonString)
 import Data.Array.NonEmpty (fromArray)
 import Data.Lens ((^?), _Just, _Right, folded, lengthOf, to)
 import Data.Lens.Index (ix)
 import Data.Maybe (Maybe(..), fromJust)
+import Partial.Unsafe (unsafePartial)
 import Prelude (Unit, ($), (<<<), (<$>), (=<<), bind, discard)
 import Test.AutomationService.Spec (Spec)
+import Test.AutomationService.Helpers (shouldHaveCapabilities)
 import Test.Fixtures (signeFixture)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
-import Partial.Unsafe (unsafePartial)
-
 
 spec :: Spec Unit
 spec =
@@ -23,23 +23,23 @@ spec =
     it "Can parse a collection of Exposes JSON" $ do
 
       let
-        signeExposes = do
+        signe = do
           obj <- fromJsonString signeFixture
           definition <- obj .: "definition"
           exposes' <- definition .:? "exposes"
           decodeExposes $ unsafePartial $ fromJust $ fromArray =<< exposes'
 
-        brightness = signeExposes ^? _Right <<< ix 1 <<< to capabilityDetails
+        brightness = signe ^? _Right <<< ix 1 <<< to capabilityDetails
         prop cap przm = cap ^? (_Just <<< przm)
         mProp cap przm = cap ^? (_Just <<< przm <<< _Just)
 
         -- I can't seem to compose these with prop/mProp without a
         -- type error about not matching String, but it highlights the
         -- `ix` call for some reason?
-        featureType = signeExposes ^? _Right <<< ix 1 <<< to capabilityDetails <<< _featureType <<< _Just
-        type' = signeExposes ^? _Right <<< ix 1 <<< to capabilityDetails <<< _type
-        access = signeExposes ^? _Right <<< ix 1 <<< to capabilityDetails <<< _access
-        subProps = signeExposes ^? _Right <<< ix 1 <<< to capabilityDetails <<< _subProps
+        featureType = signe ^? _Right <<< ix 1 <<< to capabilityDetails <<< _featureType <<< _Just
+        type' = signe ^? _Right <<< ix 1 <<< to capabilityDetails <<< _type
+        access = signe ^? _Right <<< ix 1 <<< to capabilityDetails <<< _access
+        subProps = signe ^? _Right <<< ix 1 <<< to capabilityDetails <<< _subProps
 
         subPropsFixture
           = Numeric
@@ -50,9 +50,7 @@ spec =
             }
 
 
-      -- assertions
-
-      lengthOf (folded <<< folded) signeExposes `shouldEqual` 11
+      lengthOf (folded <<< folded) signe `shouldEqual` 11
 
       type' `shouldEqual` Just Numeric'
 
@@ -75,3 +73,6 @@ spec =
       (isPublished <$> access) `shouldEqual` Just true
 
       subProps `shouldEqual` Just subPropsFixture
+
+      -- signe `shouldHaveCapabilities` [OnOff, Brightness, ColorHue]
+      signe `shouldHaveCapabilities` [OnOff, Brightness, ColorHue, Occupancy]

--- a/ui/test/src/Test/AutomationService/Group.purs
+++ b/ui/test/src/Test/AutomationService/Group.purs
@@ -1,0 +1,58 @@
+module Test.AutomationService.Group where
+
+import AutomationService.Group (decodeGroups)
+import AutomationService.Device (Decoded(..), DecodedStatus(..), Device(..), decodeDevices, details,
+                                 mkFailedParse)
+import Data.Array (head)
+import Data.Array as Array
+import Data.Argonaut.Decode (parseJson)
+import Data.Either (fromRight)
+import Data.Map as M
+import Data.Maybe (Maybe(..))
+import Data.Traversable (for_)
+import Prelude (Unit, (<<<), ($), (<$>), (=<<), discard)
+import Test.AutomationService.Helpers (shouldConstruct)
+import Test.AutomationService.Spec (Spec)
+import Test.Spec (describe, it)
+import Test.Spec.Assertions (shouldEqual)
+import Test.Fixtures (livingRoomStandingLampBulbsFixture, livingRoomStandingLampGroupFixture)
+
+spec :: Spec Unit
+spec =
+  describe "decoding Groups" $
+    it "Decode all properties of a Group" $ do
+
+      let
+        parsedJson = parseJson livingRoomStandingLampBulbsFixture
+
+        bulbs = case fromRight (mkFailedParse parsedJson) $ decodeDevices <$> parsedJson of
+          Decoded DecodingSucceeded { devices } -> devices
+          _ -> M.empty
+
+        -- code under test (decodeGroups)
+        lampGroup = head <<< fromRight [] $
+          decodeGroups bulbs =<< parseJson livingRoomStandingLampGroupFixture
+
+        lampDevices = _.members <$> lampGroup
+
+        -- helpers to reduce a little boilerplate
+        deviceAt idx ds = _.device <$> Array.index ds idx
+        deviceDetailAt idx ds detail = detail <<< details <$> deviceAt idx ds
+
+      for_ lampDevices \lampDevices' -> do
+        ExtendedColorLight `shouldConstruct` deviceAt 0 lampDevices'
+        ExtendedColorLight `shouldConstruct` deviceAt 1 lampDevices'
+        ExtendedColorLight `shouldConstruct` deviceAt 2 lampDevices'
+
+        -- should be deterministic based on the order of items in the JSON
+        Just "Living Room Standing 40W 1"
+          `shouldEqual`
+          deviceDetailAt 0 lampDevices' _.name
+
+        Just "Living Room Standing 40W 2"
+          `shouldEqual`
+          deviceDetailAt 1 lampDevices' _.name
+
+        Just "Living Room Standing 40W 3"
+          `shouldEqual`
+          deviceDetailAt 2 lampDevices' _.name

--- a/ui/test/src/Test/AutomationService/Helpers.purs
+++ b/ui/test/src/Test/AutomationService/Helpers.purs
@@ -85,16 +85,10 @@ shouldHaveCapabilities
   => t Exposes
   -> Array (CapabilityDetails -> Capability)
   -> m Unit
-shouldHaveCapabilities exposes caps = do
-  let
-    matches =
-      flip matchingCapabilities caps <$> exposes
-    isMatch = matches <#> \ms -> length ms == length caps
-
+shouldHaveCapabilities exposes caps =
   for_ isMatch \isMatch' -> do
     when (not isMatch') do
       let
-        capName cons = capabilityName <<< cons $ dummy
         capNames = show $ capName <$> caps
         matchNames = show $ matches <#> \matches' ->
           capName <$> matches'
@@ -102,6 +96,11 @@ shouldHaveCapabilities exposes caps = do
         "Does not have capabilities " <> capNames <> ", has only " <> matchNames
 
   where
+    matches = flip matchingCapabilities caps <$> exposes
+    isMatch = matches <#> \ms -> length ms == length caps
+
+    capName cons = capabilityName <<< cons $ dummy
+
     dummy :: CapabilityDetails
     dummy =
       { type: UnknownCT "dummy"

--- a/ui/test/src/Test/AutomationService/Helpers.purs
+++ b/ui/test/src/Test/AutomationService/Helpers.purs
@@ -5,18 +5,17 @@ module Test.AutomationService.Helpers
 where
 
 import AutomationService.Device (Device, DeviceDetails, details)
-import Control.Applicative (class Applicative)
-import Control.Bind (class Bind)
 import Control.Monad.Error.Class (class MonadThrow)
 import Data.Eq (class Eq)
+import Data.Functor (class Functor)
 import Data.Show (class Show)
 import Effect.Exception (Error)
-import Prelude (Unit, (<<<), (=<<), pure)
+import Prelude (Unit, (<<<), (<$>))
 import Test.Spec.Assertions (shouldEqual)
 
 -- |
 -- | shouldConstruct is a bit of a hack to allow testing
--- | of devices inside of an (Show-able, Eq-able) Applicative
+-- | of devices inside of an (Show-able, Eq-able) Functorial
 -- | context directly against a Device data constructor, a la
 -- |
 -- |     -- Maybe Device
@@ -40,17 +39,15 @@ shouldConstruct
   :: forall m t. MonadThrow Error m
   => Show (t Device)
   => Eq (t Device)
-  => Applicative t
-  => Bind t
+  => Functor t
   => (DeviceDetails -> Device)
   -> t Device
   -> m Unit
 shouldConstruct cons v = construct cons v `shouldEqual` v
 
 construct
-  :: forall m. Bind m
-  => Applicative m
+  :: forall t. Functor t
   => (DeviceDetails -> Device)
-  -> m Device
-  -> m Device
-construct cons v = pure <<< cons <<< details =<< v
+  -> t Device
+  -> t Device
+construct cons v = cons <<< details <$> v

--- a/ui/test/src/Test/AutomationService/Helpers.purs
+++ b/ui/test/src/Test/AutomationService/Helpers.purs
@@ -1,0 +1,56 @@
+module Test.AutomationService.Helpers
+  ( construct
+  , shouldConstruct
+  )
+where
+
+import AutomationService.Device (Device, DeviceDetails, details)
+import Control.Applicative (class Applicative)
+import Control.Bind (class Bind)
+import Control.Monad.Error.Class (class MonadThrow)
+import Data.Eq (class Eq)
+import Data.Show (class Show)
+import Effect.Exception (Error)
+import Prelude (Unit, (<<<), (=<<), pure)
+import Test.Spec.Assertions (shouldEqual)
+
+-- |
+-- | shouldConstruct is a bit of a hack to allow testing
+-- | of devices inside of an (Show-able, Eq-able) Applicative
+-- | context directly against a Device data constructor, a la
+-- |
+-- |     -- Maybe Device
+-- |     ExtendedColorlight `shouldConstruct` Just someDevice
+-- |
+-- |     -- Either JsonDecodeError Device
+-- |     OccupancySensor `shouldConstruct` Right someOtherDevice
+-- |
+-- | Of course you wouldn't deliberately wrap your device
+-- | in a context like this, but most of the time it's a
+-- | pain to cleanly extract a Device value from a context,
+-- | so this makes it easier to test in a way that provides
+-- | non-useless (if a bit noisy) failure output when it
+-- | fails, e.g.
+-- |
+-- |     Error:
+-- |        (Just (DimmableLight { category: "Router", exposes: (NonEmptyArray [ ... ]) ... } ) )
+-- |      ≠ (Just (ExtendedColorLight { category: "Router", exposes: (NonEmptyArray [ ... ]) ... } ) )
+-- |
+shouldConstruct
+  :: forall m t. MonadThrow Error m
+  => Show (t Device)
+  => Eq (t Device)
+  => Applicative t
+  => Bind t
+  => (DeviceDetails -> Device)
+  -> t Device
+  -> m Unit
+shouldConstruct cons v = construct cons v `shouldEqual` v
+
+construct
+  :: forall m. Bind m
+  => Applicative m
+  => (DeviceDetails -> Device)
+  -> m Device
+  -> m Device
+construct cons v = pure <<< cons <<< details =<< v

--- a/ui/test/src/Test/AutomationService/Helpers.purs
+++ b/ui/test/src/Test/AutomationService/Helpers.purs
@@ -8,7 +8,7 @@ where
 import AutomationService.Device (Device, DeviceDetails, details)
 import AutomationService.Exposes (CapType(..), Capability, CapabilityDetails, Exposes, SubProps(..), matchingCapabilities)
 import Control.Monad (when)
-import Control.Monad.Error.Class (class MonadError, class MonadThrow, throwError)
+import Control.Monad.Error.Class (class MonadThrow, throwError)
 import Data.Array (length)
 import Data.Eq (class Eq)
 import Data.Functor (class Functor)
@@ -64,9 +64,9 @@ construct cons v = cons <<< details <$> v
 
 
 -- |
--- | Slightly over the top helper for producing good failure messages
+-- | Slightly over-the-top helper for producing good failure messages
 -- | when supplying a test using an array of Capability constructors
--- | to compare against a Exposes object (a.k.a. an array of Capbility
+-- | to compare against an Exposes object (a.k.a. an array of Capbility
 -- | values), a la
 -- |
 -- |     light `shouldHaveCapabilities` [OnOff, Occupancy]
@@ -79,19 +79,18 @@ construct cons v = cons <<< details <$> v
 -- |
 shouldHaveCapabilities
   :: forall m t. MonadThrow Error m
-  => MonadError Error m
   => Traversable t
   => Show (t (Array String))
   => t Exposes
   -> Array (CapabilityDetails -> Capability)
   -> m Unit
 shouldHaveCapabilities exposes caps =
-  for_ isMatch \isMatch' -> do
+  for_ isMatch \isMatch' ->
     when (not isMatch') do
       let
         capNames = show $ capName <$> caps
-        matchNames = show $ matches <#> \matches' ->
-          capName <$> matches'
+        -- lol
+        matchNames = show $ matches <#> \matches' -> capName <$> matches'
       throwError <<< error $
         "Does not have capabilities " <> capNames <> ", has only " <> matchNames
 

--- a/ui/test/src/Test/AutomationService/Helpers.purs
+++ b/ui/test/src/Test/AutomationService/Helpers.purs
@@ -1,17 +1,27 @@
 module Test.AutomationService.Helpers
   ( construct
   , shouldConstruct
+  , shouldHaveCapabilities
   )
 where
 
 import AutomationService.Device (Device, DeviceDetails, details)
-import Control.Monad.Error.Class (class MonadThrow)
+import AutomationService.Exposes (CapType(..), Capability, CapabilityDetails, Exposes, SubProps(..), matchingCapabilities)
+import Control.Monad (when)
+import Control.Monad.Error.Class (class MonadError, class MonadThrow, throwError)
+import Data.Array (length)
 import Data.Eq (class Eq)
 import Data.Functor (class Functor)
+import Data.Generic.Rep (Constructor(..), Sum(..))
+import Data.Generic.Rep as Generic
+import Data.Maybe (Maybe(..))
 import Data.Show (class Show)
-import Effect.Exception (Error)
-import Prelude (Unit, (<<<), (<$>))
+import Data.Symbol (class IsSymbol, reflectSymbol)
+import Data.Traversable (class Traversable, for_)
+import Effect.Exception (Error, error)
+import Prelude (Unit, ($), (<<<), (<$>), (<#>), (<>), (==), flip, not, show)
 import Test.Spec.Assertions (shouldEqual)
+import Type.Proxy (Proxy(..))
 
 -- |
 -- | shouldConstruct is a bit of a hack to allow testing
@@ -51,3 +61,76 @@ construct
   -> t Device
   -> t Device
 construct cons v = cons <<< details <$> v
+
+
+-- |
+-- | Slightly over the top helper for producing good failure messages
+-- | when supplying a test using an array of Capability constructors
+-- | to compare against a Exposes object (a.k.a. an array of Capbility
+-- | values), a la
+-- |
+-- |     light `shouldHaveCapabilities` [OnOff, Occupancy]
+-- |
+-- |     -- ...produces test run failure:
+-- |
+-- |     1) Exposes
+-- |          Can parse a collection of Exposes JSON:
+-- |        Error: Does not have capabilities ["OnOff","Occupancy"], has only (Right ["OnOff"])
+-- |
+shouldHaveCapabilities
+  :: forall m t. MonadThrow Error m
+  => MonadError Error m
+  => Traversable t
+  => Show (t (Array String))
+  => t Exposes
+  -> Array (CapabilityDetails -> Capability)
+  -> m Unit
+shouldHaveCapabilities exposes caps = do
+  let
+    matches =
+      flip matchingCapabilities caps <$> exposes
+    isMatch = matches <#> \ms -> length ms == length caps
+
+  for_ isMatch \isMatch' -> do
+    when (not isMatch') do
+      let
+        capName cons = capabilityName <<< cons $ dummy
+        capNames = show $ capName <$> caps
+        matchNames = show $ matches <#> \matches' ->
+          capName <$> matches'
+      throwError <<< error $
+        "Does not have capabilities " <> capNames <> ", has only " <> matchNames
+
+  where
+    dummy :: CapabilityDetails
+    dummy =
+      { type: UnknownCT "dummy"
+      , featureType: Nothing
+      , name: "dummy"
+      , description: Nothing
+      , label: "dummy"
+      , property: Nothing
+      , access: 0
+      , subProps: Null
+      }
+
+--
+-- CapabilityName is a stupid Generic-based helper to get the
+-- Constructor name as a string. It's highly coupled to the structure
+-- of the Capability type's Generic representation, so it's a
+-- Generic-based type class in name only.
+--
+class CapabilityName a where
+  capName :: a -> String
+
+instance (CapabilityName a, CapabilityName b) => CapabilityName (Sum a b) where
+  capName = case _ of
+    Inl a -> capName a
+    Inr b -> capName b
+
+instance (IsSymbol name) => CapabilityName (Constructor name a) where
+  capName (Constructor _a) =
+    reflectSymbol (Proxy :: Proxy name)
+
+capabilityName :: Capability -> String
+capabilityName = capName <<< Generic.from

--- a/ui/test/src/Test/Fixtures.purs
+++ b/ui/test/src/Test/Fixtures.purs
@@ -594,7 +594,7 @@ humiditySensorFixture = """
         "scenes": []
       }
     },
-    "friendly_name": "Grow room temperature and humidity",
+    "friendly_name": "Temperature and humidity",
     "ieee_address": "0x0015bc0035001e14",
     "interview_completed": true,
     "interviewing": false,
@@ -608,8 +608,8 @@ humiditySensorFixture = """
   }
 """
 
-motionSensorFixture :: String
-motionSensorFixture = """
+lightSensorFixture :: String
+lightSensorFixture = """
 {
     "date_code": "20220329 07:28",
     "definition": {
@@ -1821,4 +1821,905 @@ unknownDeviceFixture = """
     "supported": true,
     "type": "EndDevice"
   }
+"""
+
+livingRoomStandingLampGroupFixture :: String
+livingRoomStandingLampGroupFixture = """
+  [
+     {
+       "friendly_name": "Living Room Standing Lamp",
+       "id": 5,
+       "members": [
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c9941c5"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b2e53"
+	 },
+	 {
+           "endpoint": 11,
+           "ieee_address": "0x001788010c3b38af"
+	 }
+       ],
+       "scenes": []
+     },
+     {
+       "friendly_name": "default_bind_group",
+       "id": 901,
+       "members": [],
+       "scenes": []
+     }
+   ]
+"""
+
+livingRoomStandingLampBulbsFixture :: String
+livingRoomStandingLampBulbsFixture = """
+[
+  {
+    "date_code": "20230116",
+    "definition": {
+      "description": "Hue White and Color Ambiance E12 with bluetooth",
+      "exposes": [
+        {
+          "features": [
+            {
+              "access": 7,
+              "description": "On/off state of this light",
+              "label": "State",
+              "name": "state",
+              "property": "state",
+              "type": "binary",
+              "value_off": "OFF",
+              "value_on": "ON",
+              "value_toggle": "TOGGLE"
+            },
+            {
+              "access": 7,
+              "description": "Brightness of this light",
+              "label": "Brightness",
+              "name": "brightness",
+              "property": "brightness",
+              "type": "numeric",
+              "value_max": 254,
+              "value_min": 0
+            },
+            {
+              "access": 7,
+              "description": "Color temperature of this light",
+              "label": "Color temp",
+              "name": "color_temp",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                }
+              ],
+              "property": "color_temp",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color temperature after cold power on of this light",
+              "label": "Color temp startup",
+              "name": "color_temp_startup",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                },
+                {
+                  "description": "Restore previous color_temp on cold power on",
+                  "name": "previous",
+                  "value": 65535
+                }
+              ],
+              "property": "color_temp_startup",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color of this light in the CIE 1931 color space (x/y)",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "X",
+                  "name": "x",
+                  "property": "x",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Y",
+                  "name": "y",
+                  "property": "y",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (X/Y)",
+              "name": "color_xy",
+              "property": "color",
+              "type": "composite"
+            },
+            {
+              "access": 7,
+              "description": "Color of this light expressed as hue/saturation",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "Hue",
+                  "name": "hue",
+                  "property": "hue",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Saturation",
+                  "name": "saturation",
+                  "property": "saturation",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (HS)",
+              "name": "color_hs",
+              "property": "color",
+              "type": "composite"
+            }
+          ],
+          "type": "light"
+        },
+        {
+          "access": 7,
+          "description": "Controls the behavior when the device is powered on after power loss",
+          "label": "Power-on behavior",
+          "name": "power_on_behavior",
+          "property": "power_on_behavior",
+          "type": "enum",
+          "values": [
+            "off",
+            "on",
+            "toggle",
+            "previous"
+          ]
+        },
+        {
+          "access": 2,
+          "label": "Effect",
+          "name": "effect",
+          "property": "effect",
+          "type": "enum",
+          "values": [
+            "blink",
+            "breathe",
+            "okay",
+            "channel_change",
+            "candle",
+            "fireplace",
+            "colorloop",
+            "finish_effect",
+            "stop_effect",
+            "stop_hue_effect"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "929002294101",
+      "options": [
+        {
+          "access": 2,
+          "description": "Controls the transition time (in seconds) of on/off, brightness, color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).",
+          "label": "Transition",
+          "name": "transition",
+          "property": "transition",
+          "type": "numeric",
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "When enabled colors will be synced, e.g. if the light supports both color x/y and color temperature a conversion from color x/y to color temperature will be done when setting the x/y color (default true).",
+          "label": "Color sync",
+          "name": "color_sync",
+          "property": "color_sync",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 2,
+          "description": "State actions will also be published as 'action' when true (default false).",
+          "label": "State action",
+          "name": "state_action",
+          "property": "state_action",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Philips"
+    },
+    "disabled": false,
+    "endpoints": {
+      "11": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "touchlink",
+            "manuSpecificSamsungAccelerometer",
+            "lightingColorCtrl",
+            "manuSpecificUbisysDimmerSetup"
+          ],
+          "output": [
+            "genOta"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "242": {
+        "bindings": [],
+        "clusters": {
+          "input": [],
+          "output": [
+            "greenPower"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Living Room Standing 40W 1",
+    "ieee_address": "0x001788010c9941c5",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "Philips",
+    "model_id": "LCE001",
+    "network_address": 52129,
+    "power_source": "Mains (single phase)",
+    "software_build_id": "1.101.10",
+    "supported": true,
+    "type": "Router"
+  },
+  {
+    "date_code": "20230116",
+    "definition": {
+      "description": "Hue White and Color Ambiance E12 with bluetooth",
+      "exposes": [
+        {
+          "features": [
+            {
+              "access": 7,
+              "description": "On/off state of this light",
+              "label": "State",
+              "name": "state",
+              "property": "state",
+              "type": "binary",
+              "value_off": "OFF",
+              "value_on": "ON",
+              "value_toggle": "TOGGLE"
+            },
+            {
+              "access": 7,
+              "description": "Brightness of this light",
+              "label": "Brightness",
+              "name": "brightness",
+              "property": "brightness",
+              "type": "numeric",
+              "value_max": 254,
+              "value_min": 0
+            },
+            {
+              "access": 7,
+              "description": "Color temperature of this light",
+              "label": "Color temp",
+              "name": "color_temp",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                }
+              ],
+              "property": "color_temp",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color temperature after cold power on of this light",
+              "label": "Color temp startup",
+              "name": "color_temp_startup",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                },
+                {
+                  "description": "Restore previous color_temp on cold power on",
+                  "name": "previous",
+                  "value": 65535
+                }
+              ],
+              "property": "color_temp_startup",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color of this light in the CIE 1931 color space (x/y)",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "X",
+                  "name": "x",
+                  "property": "x",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Y",
+                  "name": "y",
+                  "property": "y",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (X/Y)",
+              "name": "color_xy",
+              "property": "color",
+              "type": "composite"
+            },
+            {
+              "access": 7,
+              "description": "Color of this light expressed as hue/saturation",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "Hue",
+                  "name": "hue",
+                  "property": "hue",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Saturation",
+                  "name": "saturation",
+                  "property": "saturation",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (HS)",
+              "name": "color_hs",
+              "property": "color",
+              "type": "composite"
+            }
+          ],
+          "type": "light"
+        },
+        {
+          "access": 7,
+          "description": "Controls the behavior when the device is powered on after power loss",
+          "label": "Power-on behavior",
+          "name": "power_on_behavior",
+          "property": "power_on_behavior",
+          "type": "enum",
+          "values": [
+            "off",
+            "on",
+            "toggle",
+            "previous"
+          ]
+        },
+        {
+          "access": 2,
+          "label": "Effect",
+          "name": "effect",
+          "property": "effect",
+          "type": "enum",
+          "values": [
+            "blink",
+            "breathe",
+            "okay",
+            "channel_change",
+            "candle",
+            "fireplace",
+            "colorloop",
+            "finish_effect",
+            "stop_effect",
+            "stop_hue_effect"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "929002294101",
+      "options": [
+        {
+          "access": 2,
+          "description": "Controls the transition time (in seconds) of on/off, brightness, color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).",
+          "label": "Transition",
+          "name": "transition",
+          "property": "transition",
+          "type": "numeric",
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "When enabled colors will be synced, e.g. if the light supports both color x/y and color temperature a conversion from color x/y to color temperature will be done when setting the x/y color (default true).",
+          "label": "Color sync",
+          "name": "color_sync",
+          "property": "color_sync",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 2,
+          "description": "State actions will also be published as 'action' when true (default false).",
+          "label": "State action",
+          "name": "state_action",
+          "property": "state_action",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Philips"
+    },
+    "disabled": false,
+    "endpoints": {
+      "11": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "touchlink",
+            "manuSpecificSamsungAccelerometer",
+            "lightingColorCtrl",
+            "manuSpecificUbisysDimmerSetup"
+          ],
+          "output": [
+            "genOta"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "242": {
+        "bindings": [],
+        "clusters": {
+          "input": [],
+          "output": [
+            "greenPower"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Living Room Standing 40W 2",
+    "ieee_address": "0x001788010c3b2e53",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "Philips",
+    "model_id": "LCE001",
+    "network_address": 36820,
+    "power_source": "Mains (single phase)",
+    "software_build_id": "1.101.10",
+    "supported": true,
+    "type": "Router"
+  },
+  {
+    "date_code": "20230116",
+    "definition": {
+      "description": "Hue White and Color Ambiance E12 with bluetooth",
+      "exposes": [
+        {
+          "features": [
+            {
+              "access": 7,
+              "description": "On/off state of this light",
+              "label": "State",
+              "name": "state",
+              "property": "state",
+              "type": "binary",
+              "value_off": "OFF",
+              "value_on": "ON",
+              "value_toggle": "TOGGLE"
+            },
+            {
+              "access": 7,
+              "description": "Brightness of this light",
+              "label": "Brightness",
+              "name": "brightness",
+              "property": "brightness",
+              "type": "numeric",
+              "value_max": 254,
+              "value_min": 0
+            },
+            {
+              "access": 7,
+              "description": "Color temperature of this light",
+              "label": "Color temp",
+              "name": "color_temp",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                }
+              ],
+              "property": "color_temp",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color temperature after cold power on of this light",
+              "label": "Color temp startup",
+              "name": "color_temp_startup",
+              "presets": [
+                {
+                  "description": "Coolest temperature supported",
+                  "name": "coolest",
+                  "value": 150
+                },
+                {
+                  "description": "Cool temperature (250 mireds / 4000 Kelvin)",
+                  "name": "cool",
+                  "value": 250
+                },
+                {
+                  "description": "Neutral temperature (370 mireds / 2700 Kelvin)",
+                  "name": "neutral",
+                  "value": 370
+                },
+                {
+                  "description": "Warm temperature (454 mireds / 2200 Kelvin)",
+                  "name": "warm",
+                  "value": 454
+                },
+                {
+                  "description": "Warmest temperature supported",
+                  "name": "warmest",
+                  "value": 500
+                },
+                {
+                  "description": "Restore previous color_temp on cold power on",
+                  "name": "previous",
+                  "value": 65535
+                }
+              ],
+              "property": "color_temp_startup",
+              "type": "numeric",
+              "unit": "mired",
+              "value_max": 500,
+              "value_min": 150
+            },
+            {
+              "access": 7,
+              "description": "Color of this light in the CIE 1931 color space (x/y)",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "X",
+                  "name": "x",
+                  "property": "x",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Y",
+                  "name": "y",
+                  "property": "y",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (X/Y)",
+              "name": "color_xy",
+              "property": "color",
+              "type": "composite"
+            },
+            {
+              "access": 7,
+              "description": "Color of this light expressed as hue/saturation",
+              "features": [
+                {
+                  "access": 7,
+                  "label": "Hue",
+                  "name": "hue",
+                  "property": "hue",
+                  "type": "numeric"
+                },
+                {
+                  "access": 7,
+                  "label": "Saturation",
+                  "name": "saturation",
+                  "property": "saturation",
+                  "type": "numeric"
+                }
+              ],
+              "label": "Color (HS)",
+              "name": "color_hs",
+              "property": "color",
+              "type": "composite"
+            }
+          ],
+          "type": "light"
+        },
+        {
+          "access": 7,
+          "description": "Controls the behavior when the device is powered on after power loss",
+          "label": "Power-on behavior",
+          "name": "power_on_behavior",
+          "property": "power_on_behavior",
+          "type": "enum",
+          "values": [
+            "off",
+            "on",
+            "toggle",
+            "previous"
+          ]
+        },
+        {
+          "access": 2,
+          "label": "Effect",
+          "name": "effect",
+          "property": "effect",
+          "type": "enum",
+          "values": [
+            "blink",
+            "breathe",
+            "okay",
+            "channel_change",
+            "candle",
+            "fireplace",
+            "colorloop",
+            "finish_effect",
+            "stop_effect",
+            "stop_hue_effect"
+          ]
+        },
+        {
+          "access": 1,
+          "description": "Link quality (signal strength)",
+          "label": "Linkquality",
+          "name": "linkquality",
+          "property": "linkquality",
+          "type": "numeric",
+          "unit": "lqi",
+          "value_max": 255,
+          "value_min": 0
+        }
+      ],
+      "model": "929002294101",
+      "options": [
+        {
+          "access": 2,
+          "description": "Controls the transition time (in seconds) of on/off, brightness, color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).",
+          "label": "Transition",
+          "name": "transition",
+          "property": "transition",
+          "type": "numeric",
+          "value_min": 0
+        },
+        {
+          "access": 2,
+          "description": "When enabled colors will be synced, e.g. if the light supports both color x/y and color temperature a conversion from color x/y to color temperature will be done when setting the x/y color (default true).",
+          "label": "Color sync",
+          "name": "color_sync",
+          "property": "color_sync",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        },
+        {
+          "access": 2,
+          "description": "State actions will also be published as 'action' when true (default false).",
+          "label": "State action",
+          "name": "state_action",
+          "property": "state_action",
+          "type": "binary",
+          "value_off": false,
+          "value_on": true
+        }
+      ],
+      "supports_ota": true,
+      "vendor": "Philips"
+    },
+    "disabled": false,
+    "endpoints": {
+      "11": {
+        "bindings": [],
+        "clusters": {
+          "input": [
+            "genBasic",
+            "genIdentify",
+            "genGroups",
+            "genScenes",
+            "genOnOff",
+            "genLevelCtrl",
+            "touchlink",
+            "manuSpecificSamsungAccelerometer",
+            "lightingColorCtrl",
+            "manuSpecificUbisysDimmerSetup"
+          ],
+          "output": [
+            "genOta"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      },
+      "242": {
+        "bindings": [],
+        "clusters": {
+          "input": [],
+          "output": [
+            "greenPower"
+          ]
+        },
+        "configured_reportings": [],
+        "scenes": []
+      }
+    },
+    "friendly_name": "Living Room Standing 40W 3",
+    "ieee_address": "0x001788010c3b38af",
+    "interview_completed": true,
+    "interviewing": false,
+    "manufacturer": "Philips",
+    "model_id": "LCE001",
+    "network_address": 57895,
+    "power_source": "Mains (single phase)",
+    "software_build_id": "1.101.10",
+    "supported": true,
+    "type": "Router"
+  }
+]
 """

--- a/ui/test/src/Test/Runner.purs
+++ b/ui/test/src/Test/Runner.purs
@@ -4,6 +4,7 @@ import Effect (Effect)
 import Prelude (Unit, discard)
 import Test.AutomationService.Device as Test.AutomationService.Device
 import Test.AutomationService.Exposes as Test.AutomationService.Exposes
+import Test.AutomationService.Group as Test.AutomationService.Group
 import Test.AutomationService.Spec (Spec)
 import Test.Main as Test.Main
 import Test.Spec.Mocha (runMocha)
@@ -12,6 +13,7 @@ spec :: Spec Unit
 spec = do
   Test.AutomationService.Device.spec
   Test.AutomationService.Exposes.spec
+  Test.AutomationService.Group.spec
   Test.Main.spec
 
 main :: Effect Unit


### PR DESCRIPTION
Capabilities are now being decoded into specific types
Device decoding uses Capability types to decode
Groups have associated devices updated whenever devices are updated
Device parsing is a bit smarter in terms of reporting errors
Device and Groups are being tested including new Capability and Device types

UI is still a mess, but this should make it easier to clean that up next. The changes introduces for DeviceView and Lighting are just to get things to type check and run, but I will be refactoring a bunch of that shortly.