### PR TITLE
Fix up unsubscribing behavior

### DIFF
--- a/automation-service.cabal
+++ b/automation-service.cabal
@@ -144,7 +144,13 @@ test-suite automation-service-tests
     , tasty ^>= 1.4.3
     , tasty-hspec ^>= 1.2.0.4
   ghc-options:
-    -threaded
-    -rtsopts
-    "-with-rtsopts=-N -T"
+    --
+    -- Turns out the integration tests flake out really badly when I
+    -- run this in threaded mode, so skipping for now. Seems like
+    -- there may be a few different reasons for this, including
+    -- resources leaking across `around` calls somehow?
+    --
+    -- -threaded
+    -- -rtsopts
+    -- "-with-rtsopts=-N -T"
     -Wall

--- a/src/Service/App.hs
+++ b/src/Service/App.hs
@@ -10,6 +10,7 @@ module Service.App
   , publish
   , runAutomationService
   , subscribe
+  , unsubscribe
   , warn
   )
   where
@@ -101,6 +102,13 @@ subscribe
   -> m ()
 subscribe topic =
   view mqttClient >>= \mc -> liftIO $ subscribeMQTT mc topic
+
+unsubscribe
+  :: (Logger l, MQTTClient mc, MonadReader (Env l mc) m, MonadIO m)
+  => Topic
+  -> m ()
+unsubscribe topic =
+  view mqttClient >>= \mc -> liftIO $ unsubscribeMQTT mc topic
 
 
 -- not sure where to put this, but eventually I want to just get rid

--- a/src/Service/Automations/HTTP.hs
+++ b/src/Service/Automations/HTTP.hs
@@ -106,7 +106,7 @@ mkRunAutomation port broadcastChan = do
       -> TVar (HashMap GroupId Group)
       -> TChan Daemon.Message
       -> WS.ServerApp
-    ws logger' devicesRaw groupsRaw devicesTV groupsTV daemonBC pending  = do
+    ws logger' devicesRaw groupsRaw devicesTV groupsTV daemonBC pending = do
       logDebugMsg logger' "WebSockets connected"
       conn <- WS.acceptRequest pending
 

--- a/src/Service/Env.hs
+++ b/src/Service/Env.hs
@@ -4,7 +4,7 @@ module Service.Env
   ( module Service.Env.Config
   , AutomationEntry
   , Env(..)
-  , MQTTDispatch
+  , Subscriptions
   , Registrations
   , RestartConditions(..)
   , ScheduledJobs
@@ -26,7 +26,7 @@ module Service.Env
   , logger
   , messageChan
   , mqttClient
-  , mqttDispatch
+  , subscriptions
   , notAlreadyRestarted
   , restartConditions
   , scheduledJobs
@@ -47,7 +47,7 @@ import Network.MQTT.Topic (Topic, unTopic)
 import Service.App.Logger (Logger (..))
 import qualified Service.Automation as Automation
 import Service.Automation (Automation)
-import Service.AutomationName (AutomationName)
+import Service.AutomationName (AutomationName(..))
 import Service.Device (Device, DeviceId)
 import Service.Env.Config (Config, LogLevel (..), MQTTConfig (..), automationServiceTopic,
                            configDecoder, dbPath, httpPort, logFilePath, logLevel, luaScriptPath,
@@ -79,7 +79,7 @@ invertRegistrations = M.foldlWithKey'
 
 
 type MsgAction = Topic -> ByteString -> IO ()
-type MQTTDispatch = HashMap Topic (NonEmpty MsgAction)
+type Subscriptions = HashMap Topic (HashMap AutomationName MsgAction)
 
 type ScheduledJobs =
   HashMap Daemon.JobId (Daemon.AutomationSchedule, Daemon.Message, ThreadId)
@@ -98,7 +98,7 @@ data Env logger mqttClient = Env
   { _config              :: Config
   , _logger              :: logger
   , _mqttClient          :: mqttClient
-  , _mqttDispatch        :: TVar MQTTDispatch
+  , _subscriptions       :: TVar Subscriptions
   , _daemonBroadcast     :: TChan Daemon.Message
   , _automationBroadcast :: TChan Automation.Message
   , _messageChan         :: TChan Daemon.Message
@@ -122,7 +122,7 @@ initialize
   :: (Logger logger, MQTTClient mqttClient)
   => FilePath
   -> (Config -> IO (logger, IO ()))
-  -> (Config -> logger -> TVar MQTTDispatch -> IO (mqttClient, IO ()))
+  -> (Config -> logger -> TVar Subscriptions -> IO (mqttClient, IO ()))
   -> IO (Env logger mqttClient)
 initialize configFilePath mkLogger mkMQTTClient = do
   -- need to handle a configuration error? Dhall provides a lot of error output
@@ -132,12 +132,12 @@ initialize configFilePath mkLogger mkMQTTClient = do
 
   (logger', loggerCleanup) <- mkLogger config'
 
-  mqttDispatch' <- newTVarIO $ defaultTopicActions config' daemonBroadcast'
-  (mc, mcCleanup) <- mkMQTTClient config' logger' mqttDispatch'
+  subscriptions' <- newTVarIO $ defaultTopicActions config' daemonBroadcast'
+  (mc, mcCleanup) <- mkMQTTClient config' logger' subscriptions'
 
   automationBroadcast' <- newBroadcastTChanIO
 
-  Env config' logger' mc mqttDispatch' daemonBroadcast' automationBroadcast'
+  Env config' logger' mc subscriptions' daemonBroadcast' automationBroadcast'
     <$> (atomically $ dupTChan daemonBroadcast') -- messageChan
     <*> (newTVarIO M.empty) -- devices
     <*> (newTVarIO M.empty) -- deviceRegistrations
@@ -150,38 +150,45 @@ initialize configFilePath mkLogger mkMQTTClient = do
     <*> (newTVarIO "")      -- groupsRawJSON
     <*> pure (loggerCleanup >> mcCleanup)
 
+
+defaultTopicActions :: Config -> TChan Daemon.Message -> Subscriptions
+defaultTopicActions config' daemonBroadcast' =
+  let
+    (automationServiceTopic', statusTopic') =
+      config' ^. mqttConfig . lensProduct automationServiceTopic statusTopic
+    setTopic = parseTopic . (<> "/set") . unTopic $ automationServiceTopic'
+  in
+    M.fromList
+      [ ( setTopic
+        , M.singleton Null (\_topic msg -> for_ (decode msg) $ write daemonBroadcast')
+        )
+
+      , ( Zigbee2MQTT.devicesTopic
+        , M.singleton Null
+          (\_topic msg ->
+             case decode msg of
+               Just [] -> pure ()
+               Nothing -> pure ()
+               Just devicesJSON -> do
+                 write daemonBroadcast' $ Daemon.DeviceUpdate devicesJSON msg
+          )
+        )
+
+      , ( Zigbee2MQTT.groupsTopic
+        , M.singleton Null
+          (\_topic msg ->
+             case decode msg of
+               Just [] -> pure ()
+               Nothing -> pure ()
+               Just groupsJSON -> do
+                 write daemonBroadcast' $ Daemon.GroupUpdate groupsJSON msg
+          )
+        )
+
+      , ( statusTopic'
+        , M.singleton Null (\_topic _msg -> write daemonBroadcast' Daemon.Status)
+        )
+      ]
   where
     write :: TChan Daemon.Message -> Daemon.Message -> IO ()
-    write daemonBroadcast' = atomically . writeTChan daemonBroadcast'
-
-    defaultTopicActions config' daemonBroadcast' =
-      let
-        (automationServiceTopic', statusTopic') =
-          config' ^. mqttConfig . lensProduct automationServiceTopic statusTopic
-        setTopic = parseTopic . (<> "/set") . unTopic $ automationServiceTopic'
-      in
-        M.fromList
-          [ (setTopic, (\_topic msg -> for_ (decode msg) $ write daemonBroadcast') :| [])
-
-          , (Zigbee2MQTT.devicesTopic,
-             (\_topic msg ->
-                case decode msg of
-                  Just [] -> pure ()
-                  Nothing -> pure ()
-                  Just devicesJSON -> do
-                    write daemonBroadcast' $ Daemon.DeviceUpdate devicesJSON msg
-             ) :| []
-            )
-
-          , (Zigbee2MQTT.groupsTopic,
-             (\_topic msg ->
-                case decode msg of
-                  Just [] -> pure ()
-                  Nothing -> pure ()
-                  Just groupsJSON -> do
-                    write daemonBroadcast' $ Daemon.GroupUpdate groupsJSON msg
-             ) :| []
-            )
-
-          , (statusTopic', (\_topic _msg -> write daemonBroadcast' Daemon.Status) :| [])
-          ]
+    write daemonBroadcast'' = atomically . writeTChan daemonBroadcast''

--- a/src/Service/MQTT/Class.hs
+++ b/src/Service/MQTT/Class.hs
@@ -11,9 +11,15 @@ import Network.MQTT.Topic (Topic, toFilter)
 class MQTTClient a where
   publishMQTT :: a -> Topic -> ByteString -> IO ()
   subscribeMQTT :: a -> Topic -> IO ()
+  unsubscribeMQTT :: a -> Topic -> IO ()
 
 instance MQTTClient (MQTT.MQTTClient) where
   publishMQTT mc topic msg = MQTT.publish mc topic msg False
   subscribeMQTT mc topic =
     -- handle response properly!
     void $ MQTT.subscribe mc [(toFilter topic, MQTT.subOptions)] []
+  unsubscribeMQTT mc topic =
+    -- ditto
+    -- https://hackage.haskell.org/package/net-mqtt-0.8.6.2/docs/Network-MQTT-Client.html#g:3
+    -- In MQTT 3.1.1, there is no body to an unsubscribe response, so it can be ignored. If this returns, you were unsubscribed. In MQTT 5, you'll get a list of unsub status values corresponding to your request filters, and whatever properties the server thought you should know about.
+    void $ MQTT.unsubscribe mc [toFilter topic] []

--- a/test/Test/Integration/Service/Daemon.hs
+++ b/test/Test/Integration/Service/Daemon.hs
@@ -39,7 +39,7 @@ import Service.Automation (name)
 import Service.AutomationName (AutomationName (..), parseAutomationName, serializeAutomationName)
 import Service.Env (RestartConditions (..), automationServiceTopic, config, daemonBroadcast, dbPath,
                     deviceRegistrations, devicesRawJSON, groupRegistrations, httpPort, logger,
-                    mqttClient, mqttConfig, mqttDispatch, restartConditions, scheduledJobs)
+                    mqttClient, mqttConfig, subscriptions, restartConditions, scheduledJobs)
 import qualified Service.MQTT.Messages.Daemon as Daemon
 import qualified Service.StateStore as StateStore
 import System.Environment (setEnv)
@@ -154,7 +154,7 @@ luaScriptSpecs = do
 
   -- flaky
   around initAndCleanup $ do
-    xit "allows scripts to register devices" $
+    it "allows scripts to register devices" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
@@ -167,7 +167,8 @@ luaScriptSpecs = do
         atomically $ writeTChan daemonBroadcast' $ Daemon.Start (LuaScript "testRegistration")
 
         -- see comment in test below
-        threadDelay 10000
+        -- so does this just need more time
+        threadDelay 100000
 
         mirrorLightAutos <- readTVarIO registrations <&> M.lookup mirrorLightID
         mirrorLightAutos
@@ -195,15 +196,14 @@ luaScriptSpecs = do
           `shouldBe`
           (Just (LuaScript "testRegistration" :| [Gold]))
 
-  -- flaky
   -- I don't love this test
   around initAndCleanup $ do
-    xit "subscribes to topic and receives topic messages" $
+    it "subscribes to topic and receives topic messages, and removes subscription *internally* when automation is stopped" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
           (TestLogger qLogger) = env ^. logger
-          mqttDispatch' = env ^. mqttDispatch
+          subscriptions' = env ^. subscriptions
           Just topic = mkTopic "testTopic"
           expectedLogEntry = "Debug: testSubscribe: Msg: hey"
 
@@ -211,7 +211,7 @@ luaScriptSpecs = do
 
         --
         -- Seems like without a small wait here, the read on
-        -- mqttDispatch' below produces a deadlock on that TVar and
+        -- subscriptions' below produces a deadlock on that TVar and
         -- makes this time out, which I guess I should have assumed?
         --
         -- Somehow I thought readTVarIO wouldn't behave that way
@@ -219,9 +219,9 @@ luaScriptSpecs = do
         -- `atomically . readTVar` but works much faster, because it
         -- doesn't perform a complete transaction," but I guess I'm
         -- misunderstanding? Or, is what is causing the deadlock/timeout
-        -- not the read on the mqttDispatch TVar?
+        -- not the read on the subscriptions TVar?
         --
-        -- Previously I was doing `readTVarIO mqttDispatch'` in a
+        -- Previously I was doing `readTVarIO subscriptions'` in a
         -- loop, and then tried it with the retry package (retrying
         -- with various policies, including backoff and explicit
         -- delays for a fixed number of times). Finally I realized
@@ -250,8 +250,12 @@ luaScriptSpecs = do
         --
         threadDelay 80000
 
-        dispatchActions <- M.lookup topic <$> readTVarIO mqttDispatch'
+        dispatchActions <- M.lookup topic <$> readTVarIO subscriptions'
         for_ (fromJust dispatchActions) (\action -> action topic "{\"msg\": \"hey\"}")
+
+        waitUntilEq True $ do
+          subscriptions'' <- readTVarIO subscriptions'
+          pure . M.member topic $ subscriptions''
 
         -- Probably the slowest part of the entire test suite. Would
         -- be good to find another way to test this. Also the lookup
@@ -260,9 +264,16 @@ luaScriptSpecs = do
           logs <- readTVarIO qLogger
           pure . fromMaybe "" . headMay . filter (== expectedLogEntry) $ logs
 
-  -- flaky?
+        atomically $ writeTChan daemonBroadcast' $ Daemon.Stop (LuaScript "testSubscribe")
+
+        -- the topic should be removed since there are no other
+        -- subscribers once we stop the Automation
+        waitUntilEq False $ do
+          subscriptions'' <- readTVarIO subscriptions'
+          pure $ M.member topic subscriptions''
+
   around initAndCleanup $ do
-    xit "removes Device and Group Registration entries upon cleanup" $
+    it "removes Device and Group Registration entries upon cleanup" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
@@ -295,7 +306,7 @@ luaScriptSpecs = do
 
   -- flaky
   around initAndCleanup $ do
-    xit "retrieves dates for Sun events (rise & set)" $
+    it "retrieves dates for Sun events (rise & set)" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
 
         setEnv "TZ" "America/New_York"
@@ -320,7 +331,7 @@ luaScriptSpecs = do
         length matches `shouldBe` 2
 
   around initAndCleanup $ do
-    xit "can send Daemon messages in Lua scripts" $
+    it "can send Daemon messages in Lua scripts" $
       testWithAsyncDaemon $ \env _threadMapTV daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
@@ -352,7 +363,6 @@ threadMapSpecs = do
         waitUntilEqSTM (Just Gold) $
           preview (ix Gold . _1 . name) <$> readTVar threadMapTV
 
-  -- flaky? -seen again
   around initAndCleanup $ do
     it "removes entries from ThreadMap when stopping" $
       testWithAsyncDaemon $ \env threadMapTV _daemonSnooper -> do
@@ -370,9 +380,8 @@ threadMapSpecs = do
         -- value
         (void . M.lookup Gold) threadMap `shouldBe` Nothing
 
-  -- flaky
   around initAndCleanup $ do
-    xit "removes entries from ThreadMap for LuaScript automations as well after stopping" $
+    it "removes entries from ThreadMap for LuaScript automations as well after stopping" $
       testWithAsyncDaemon $ \env threadMapTV _daemonSnooper -> do
         let daemonBroadcast' = env ^. daemonBroadcast
 
@@ -390,7 +399,6 @@ threadMapSpecs = do
         -- same as above wrt void
         (void . M.lookup (LuaScript "test")) threadMap' `shouldBe` Nothing
 
-  -- flaky
   around initAndCleanup $ do
     --
     -- This preserves this semantics that starting an Automation that
@@ -418,7 +426,6 @@ threadMapSpecs = do
             gold1ThreadStatus `shouldBe` ThreadFinished
           Nothing -> expectationFailure "Couldn't find Gold instance 1 in threadMap"
 
-  -- flaky? x2
   around initAndCleanup $ do
     it "removes entries from ThreadMap for automations when they are not shut down via message" $
       testWithAsyncDaemon $ \env threadMapTV _daemonSnooper -> do
@@ -460,9 +467,8 @@ stateStoreSpecs = do
         -- should always be present.
         findMatchingSerialized "StateManager" res `shouldBe` ["StateManager"]
 
-  -- flaky, this fails because the db is locked
   around initAndCleanup $ do
-    xit "updates stored automations when an automation is shut down" $
+    it "updates stored automations when an automation is shut down" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
@@ -532,7 +538,7 @@ stateStoreSpecs = do
 
         --
         -- This is because scripts are often dependent on loading
-        -- groups and devices--and I don't device/group registration
+        -- groups and devices--and I don't (?) device/group registration
         -- to block in scripts, even if I have some kind of
         -- exponential backoff failure thing which eventually logs,
         -- since regardless that will prevent speedy diagnosis when
@@ -655,7 +661,6 @@ stateStoreSpecs = do
 
 schedulerSpecs :: Spec
 schedulerSpecs = do
-  -- flaky? x2
   around initAndCleanup $ do
     it "stores Schedule jobs when they come in, and removes then when Unscheduled" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
@@ -689,9 +694,8 @@ schedulerSpecs = do
 
 statusMessageSpecs :: Spec
 statusMessageSpecs = do
-  -- flaky
   around initAndCleanup $ do
-    xit "sends a status message when Daemon.Status is received" $
+    it "sends a status message when Daemon.Status is received" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           daemonBroadcast' = env ^. daemonBroadcast
@@ -720,9 +724,8 @@ statusMessageSpecs = do
 
 httpSpecs :: Spec
 httpSpecs = do
-  -- flaky, just times-out sometimes for no reason I can understand
   around initAndCleanup $ do
-    xit "sends device data over websockets" $
+    it "sends device data over websockets" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
         let
           port = env ^. config . httpPort
@@ -739,6 +742,7 @@ httpSpecs = do
             pure msg
 
         devices' <- readTVarIO devices
+
         devicesReceived `shouldBe` devices'
 
   around initAndCleanup $ do

--- a/test/Test/Integration/Service/DaemonTestHelpers.hs
+++ b/test/Test/Integration/Service/DaemonTestHelpers.hs
@@ -8,6 +8,8 @@ module Test.Integration.Service.DaemonTestHelpers
   )
   where
 
+import Debug.Trace (traceM)
+
 import Control.Lens (view, (%~), (&), (^.))
 import Data.ByteString.Lazy (ByteString)
 import Data.HashMap.Strict (HashMap)
@@ -43,6 +45,7 @@ instance MQTTClient TestMQTTClient where
     atomically $ modifyTVar' mc $ \mqttMsgs ->
       M.insert topic msg mqttMsgs
   subscribeMQTT (TestMQTTClient _mc) _topic = pure ()
+  unsubscribeMQTT (TestMQTTClient _mc) _topic = pure ()
 
 instance Logger TestLogger where
   log :: TestLogger -> LogLevel -> Text -> IO ()
@@ -86,6 +89,9 @@ initAndCleanup runTests = bracket
         writeTVar groupsJsonTV groupsJSON
 
       uuid <- UUID.nextRandom
+
+      -- traceM "Does this run every test"
+
       pure $
         env & config . dbPath %~ \dp -> dp <> "-" <> UUID.toString uuid <> ".db"
   )


### PR DESCRIPTION
Disables threaded test runs; removes subscriptions associated with anautomation when the automation is shut down, adds test assertion re: unsubscribing