### PR TITLE
Fix bug introduces in PR #39 - overzealous topic unsubscribing in automation subscription cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Running main application test suite:
 
 ```shell
 # watchexec is handy:
-> watchexec -w test -w src -w app -i "*.db" -i "test/dbs/*" 'cabal test --test-show-details=always --test-options "--color=always"'
+> watchexec -w test -w src -w app -i "*.db" -i "test/dbs/*" 'cabal test --test-show-details=always --test-options "--color=always --reporter=local"' # local reporter so we list each test result in the console vs. sending to an xml file.
 > cabal test --test-show-details=always --test-options '--color=always -l -p Unit'
 > cabal test --test-show-details=always --test-options '--color=always -l -p Integration'
 ```

--- a/automation-service.cabal
+++ b/automation-service.cabal
@@ -48,6 +48,7 @@ common shared
     , mtl ^>= 2.3.1
     , net-mqtt ^>= 0.8.6.0
     , network-uri ^>= 2.6.4.2
+    , optparse-applicative ^>= 0.18.1.0
     , pretty-simple
     , random ^>= 1.2.1.2
     , retry ^>= 0.9.3.1

--- a/src/Service/Automation.hs
+++ b/src/Service/Automation.hs
@@ -26,6 +26,7 @@ import UnliftIO.STM (TChan)
 data ClientMsg
   = ByteStringMsg [ByteString]
   | ValueMsg Value
+  | Shutdown
   deriving (Eq, Generic, Show)
 
 makePrisms ''ClientMsg

--- a/src/Service/Automations/LuaScript.hs
+++ b/src/Service/Automations/LuaScript.hs
@@ -392,10 +392,8 @@ loadAPI filepath logger' mqttClient' daemonBroadcast' broadcastChan devices' gro
                   msg <- atomically . readTChan $ listenerChan
                   case msg of
                     (Client autoName Shutdown)
-                      -- this should be something very distinct that
-                      -- is easy to match on in a Lua context (or will
-                      -- it matter at the point this receives
-                      -- AsyncCancelled?)
+                      -- this is here to enable AsyncCancelled to get
+                      -- picked up if readTChan is blocking
                       | autoName == thisAutoName -> pure "Shutdown"
                       | otherwise -> go
                     (Client autoName (ValueMsg v))

--- a/src/Service/Automations/LuaScript.hs
+++ b/src/Service/Automations/LuaScript.hs
@@ -391,6 +391,13 @@ loadAPI filepath logger' mqttClient' daemonBroadcast' broadcastChan devices' gro
                 go = do
                   msg <- atomically . readTChan $ listenerChan
                   case msg of
+                    (Client autoName Shutdown)
+                      -- this should be something very distinct that
+                      -- is easy to match on in a Lua context (or will
+                      -- it matter at the point this receives
+                      -- AsyncCancelled?)
+                      | autoName == thisAutoName -> pure "Shutdown"
+                      | otherwise -> go
                     (Client autoName (ValueMsg v))
                       | autoName == thisAutoName -> pure v
                       | otherwise -> go

--- a/src/Service/Daemon.hs
+++ b/src/Service/Daemon.hs
@@ -515,7 +515,6 @@ run' threadMapTV = do
       -- type Subscriptions = HashMap Topic (HashMap AutomationName MsgAction)
       subscriptions' <- view subscriptions
       topicsToUnsub <- atomically $
-        -- maybe this should be in a separate module?
         let updatedSubscriptions subs =
               M.foldrWithKey'
               (\topic actions (unsubTopics, updated) ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,23 +5,70 @@ module Main
   )
 where
 
+import Data.Functor ((<&>))
+import Data.List (isPrefixOf)
+import Data.Proxy (Proxy(..))
+import Data.Typeable (Typeable)
+import qualified Options.Applicative as OptApp
+import System.Environment (getArgs)
 import qualified Test.Integration.Service.Daemon as Daemon
-import Test.Tasty (TestTree, defaultIngredients, defaultMainWithIngredients, localOption, mkTimeout, testGroup)
+import Test.Tasty (TestTree, defaultIngredients, defaultMainWithIngredients, includingOptions, localOption, mkTimeout, testGroup)
 import Test.Tasty.Hspec (TreatPendingAs (..), testSpec)
-import qualified Test.Tasty.Runners.Reporter as Reporter
+import Test.Tasty.Ingredients.ConsoleReporter (consoleTestReporter)
+import Test.Tasty.Options (OptionDescription(..), IsOption(..))
+import qualified Test.Tasty.Runners.Reporter as CIReporter
 import qualified Test.Unit.Service.Device as Devices
 import qualified Test.Unit.Service.Group as Groups
 import qualified Test.Unit.Service.MQTT.Messages.Daemon as Daemon.Messages
 import qualified Test.Unit.Service.MQTT.Status as MQTTStatus
 import qualified Test.Unit.Service.TimeHelpers as TimeHelpers
 
+
 timeout :: Integer
 timeout = 10
 
+newtype ReporterOpt = ReporterOpt String
+  deriving (Eq, Ord, Typeable, Show)
+
+instance IsOption ReporterOpt where
+  defaultValue = ReporterOpt "ci"
+  parseValue = \case
+    "local" -> Just (ReporterOpt "local")
+    _ -> Just defaultValue
+  optionName = pure "reporter"
+  optionHelp =
+    pure "Reporter type: local or CI. Default is CI, which produces XML output for feeding into Allure Report. The 'local' option enables the default Tasty consoleTestReporter which is nicer to read when you're writing tests in your local environment."
+
+reporterParser :: OptApp.Parser ReporterOpt
+reporterParser = optionCLParser
+
+parseReporter :: [String] -> IO ReporterOpt
+parseReporter = OptApp.handleParseResult .
+  (OptApp.execParserPure
+    OptApp.defaultPrefs
+    (OptApp.info reporterParser OptApp.fullDesc))
+
 main :: IO ()
-main = defaultMainWithIngredients defaultIngredients' =<< allTests
+main = do
+  reporterArgs <- getArgs <&>
+    filter (\arg -> "--reporter" `isPrefixOf` arg)
+
+  reporter :: ReporterOpt <-
+    if null reporterArgs then
+      pure defaultValue
+    else
+      parseReporter reporterArgs
+
+  case reporter of
+    ReporterOpt "local" ->
+      defaultMainWithIngredients defaultIngredientsLocal' =<< allTests
+    _ ->
+      defaultMainWithIngredients defaultIngredientsCI' =<< allTests
+
   where
-    defaultIngredients' = Reporter.ingredient : defaultIngredients
+    reporterOptIngredient = includingOptions [Option (Proxy :: Proxy ReporterOpt)]
+    defaultIngredientsCI' = CIReporter.ingredient : reporterOptIngredient : defaultIngredients
+    defaultIngredientsLocal' = consoleTestReporter : reporterOptIngredient : defaultIngredients
 
 allTests :: IO TestTree
 allTests = do

--- a/test/Test/Integration/Service/Daemon.hs
+++ b/test/Test/Integration/Service/Daemon.hs
@@ -207,46 +207,11 @@ luaScriptSpecs = do
 
         atomically $ writeTChan daemonBroadcast' $ Daemon.Start (LuaScript "testSubscribe")
 
-        --
-        -- Seems like without a small wait here, the read on
-        -- subscriptions' below produces a deadlock on that TVar and
-        -- makes this time out, which I guess I should have assumed?
-        --
-        -- Somehow I thought readTVarIO wouldn't behave that way
-        -- because of docs [0] saying that, "this is equivalent to
-        -- `atomically . readTVar` but works much faster, because it
-        -- doesn't perform a complete transaction," but I guess I'm
-        -- misunderstanding? Or, is what is causing the deadlock/timeout
-        -- not the read on the subscriptions TVar?
-        --
-        -- Previously I was doing `readTVarIO subscriptions'` in a
-        -- loop, and then tried it with the retry package (retrying
-        -- with various policies, including backoff and explicit
-        -- delays for a fixed number of times). Finally I realized
-        -- that, no matter what, if I didn't have the delay here it
-        -- would lock up, and otherwise I didn't really need to do
-        -- anything but check it once like I'm now doing below. but I
-        -- still don't understand why it doesn't work without this
-        -- delay first.
-        --
-        -- NOTE this was written before I switched from using
-        -- tryReadTChan (does not block, returns Nothing when nothing
-        -- is present, so it is appropriate for polling) to readTChan
-        -- (blocks) in LuaScript subscribe functions. the readTVarIO
-        -- lookup does not block any more, but I still need the
-        -- threadDelay.
-        --
-        -- [0] https://hackage.haskell.org/package/base-4.16.3.0/docs/GHC-Conc.html#v:readTVarIO
-        --
-        -- SECOND NOTE: update after added sqlite state-storage to the
-        -- mix, now the smallest I can make this without having tests
-        -- fail is 60000 microseconds.
-        --
-        -- Part 3: moved all the functions that weren't exposed at the
-        -- module level to where terms, seemed to slow everything down
-        -- somehow?
-        --
-        threadDelay 80000
+        -- Under 20000 seems to produce deadlocks/hanging, so giving it a
+        -- little buffer and leaving it at 25000. Previously seemed like it
+        -- needed 60-80k but I suspect removing concurrency changed the
+        -- behavior here somehow.
+        threadDelay 25000
 
         dispatchActions <- M.lookup topic <$> readTVarIO subscriptions'
         for_ (fromJust dispatchActions) (\action -> action topic "{\"msg\": \"hey\"}")
@@ -270,33 +235,18 @@ luaScriptSpecs = do
           subscriptions'' <- readTVarIO subscriptions'
           pure $ M.member topic subscriptions''
 
-        -- I introduced a bug with cleanAutomations, so adding a
-        -- follow-up restart/stop to confirm this is fixed
+        -- I introduced a bug with cleanAutomations where it was
+        -- unsubscribing from too many topics, so adding a check to
+        -- confirm our subscribe/unsubscribe calls via the MQTT client
+        -- mock:
+        waitUntilEq [ "subscribe testTopic"
+                    , "unsubscribe testTopic"
+                    ] $ do
+          let
+            (TestMQTTClient testmcTV) = env ^. mqttClient
+          (mqttHistory, _mqttClient') <- readTVarIO testmcTV
+          pure mqttHistory
 
-        atomically $ writeTChan daemonBroadcast' $ Daemon.Start (LuaScript "testSubscribe")
-
-        waitUntilEq True $ do
-          subscriptions'' <- readTVarIO subscriptions'
-          pure . M.member topic $ subscriptions''
-
-        atomically $ writeTChan daemonBroadcast' $ Daemon.Stop (LuaScript "testSubscribe")
-
-        -- (again) the topic should be removed since there are no
-        -- other subscribers once we stop the Automation
-        waitUntilEq False $ do
-          subscriptions'' <- readTVarIO subscriptions'
-          pure $ M.member topic subscriptions''
-
-        let
-          (TestMQTTClient testmcTV) = env ^. mqttClient
-        (mqttHistory, _mqttClient') <- readTVarIO testmcTV
-
-        mqttHistory `shouldBe`
-          [ "subscribe testTopic"
-          , "unsubscribe testTopic"
-          , "subscribe testTopic"
-          , "unsubscribe testTopic"
-          ]
 
   around initAndCleanup $ do
     it "removes Device and Group Registration entries upon cleanup" $
@@ -332,7 +282,7 @@ luaScriptSpecs = do
 
   -- flaky
   around initAndCleanup $ do
-    xit "retrieves dates for Sun events (rise & set)" $
+    it "retrieves dates for Sun events (rise & set)" $
       testWithAsyncDaemon $ \env _threadMapTV _daemonSnooper -> do
 
         setEnv "TZ" "America/New_York"

--- a/test/lua-automations/testSubscribe.lua
+++ b/test/lua-automations/testSubscribe.lua
@@ -11,3 +11,6 @@ function loop ()
 
    sleep(1)
 end
+
+function cleanup()
+end


### PR DESCRIPTION
I introduced a bug in https://github.com/ddellacosta/automation-service/pull/39 because of an incorrect predicate and a lack of tests around topic unsubscribing behavior in automation cleanup.

This PR introduces a fix for that issue, along with a few other things:
* adds a command-line flag for Tasty (via cabal test) to switch reporter so I can use the default `consoleTestReporter` when running tests in my local environment as that output is much more useful in a terminal.
* ensures we send a shutdown message to topic subscriptions in LuaScript automations, as those were locked and preventing `cancel` calls from succeeding--ensuring a read from the `TChan` happened after `cancel` was called addressed this. (Still not sure why I didn't see this behavior with some automations in my home setup though...)